### PR TITLE
feat/docs: add setup feature documentation

### DIFF
--- a/src/modules/setup/application/mappers/setup-progress.mapper.ts
+++ b/src/modules/setup/application/mappers/setup-progress.mapper.ts
@@ -4,6 +4,9 @@ import { SetupProgress } from '../../domain/entities/setup-progress.entity';
 
 @Injectable()
 export class SetupProgressMapper {
+  /**
+   * Convert a {@link SetupProgress} entity into its DTO representation.
+   */
   static toDto(setupProgress: SetupProgress): SetupProgressDto {
     return {
       step: setupProgress.step,
@@ -13,6 +16,9 @@ export class SetupProgressMapper {
     };
   }
 
+  /**
+   * Convert a {@link SetupProgressDto} back into a domain entity.
+   */
   static fromDto(dto: SetupProgressDto): SetupProgress {
     return {
       id: dto.id,

--- a/src/modules/setup/application/use-cases/complete-setup-step.use-case.ts
+++ b/src/modules/setup/application/use-cases/complete-setup-step.use-case.ts
@@ -3,7 +3,6 @@ import { Injectable, Inject, BadRequestException } from '@nestjs/common';
 import { SetupStep } from '../dto/setup-status.dto';
 import { SetupProgress } from '../../domain/entities/setup-progress.entity';
 import { SetupProgressRepositoryInterface } from '../../domain/interfaces/setup.repository.interface';
-import { SetupStatusMapper } from '../mappers/setup-status.mapper';
 import { SetupProgressMapper } from '../mappers/setup-progress.mapper';
 
 @Injectable()
@@ -13,6 +12,18 @@ export class CompleteSetupStepUseCase {
     private readonly setupProgressRepo: SetupProgressRepositoryInterface,
   ) {}
 
+  /**
+   * Mark a specific setup step as completed for the given user.
+   *
+   * This method prevents duplicate completion of the same step by checking if
+   * a progress entry already exists. It then records the completion time and
+   * optional metadata associated with the step.
+   *
+   * @param step - The setup step to complete
+   * @param userId - Identifier of the user completing the step
+   * @param metadata - Additional information to store with the progress record
+   * @returns The persisted {@link SetupProgress} entity
+   */
   async execute(
     step: SetupStep,
     userId: string,

--- a/src/modules/setup/application/use-cases/complete-vm-discovery.use-case.ts
+++ b/src/modules/setup/application/use-cases/complete-vm-discovery.use-case.ts
@@ -17,16 +17,16 @@ export class CompleteVmDiscoveryUseCase {
   ) {}
 
   /**
-   * Completes the VM discovery step in the setup process.
-   * This method checks if the server exists and if the server creation step has been completed.
-   * If the server creation step is not completed, it throws a BadRequestException.
-   * If the server exists and the step is completed, it calls the completeSetupStepUseCase to mark the VM discovery step as completed.
+   * Finalize the VM discovery phase of the setup workflow.
    *
+   * Validates that the target server exists and that the server creation step
+   * has already been completed before recording the discovery results.
+   * If validation passes, the underlying `CompleteSetupStepUseCase` is invoked
+   * to store the completion information.
    *
-   * @param userId
-   * @param discoveryResult
-   *
-   * @returns {Promise<void>} - A promise that resolves when the VM discovery step is successfully completed.
+   * @param userId - ID of the user performing the discovery
+   * @param discoveryResult - Details about the discovered VMs
+   * @returns Resolves once the discovery results are saved
    */
   async execute(
     userId: string,

--- a/src/modules/setup/application/use-cases/get-setup-status.use-case.ts
+++ b/src/modules/setup/application/use-cases/get-setup-status.use-case.ts
@@ -112,9 +112,10 @@ export class GetSetupStatusUseCase {
   }
 
   /**
+   * Check if the VM discovery step has already been completed.
    *
-   *
-   * @returns
+   * @returns `true` when a progress entry exists for the VM discovery step,
+   *   otherwise `false`.
    */
   private async hasCompletedVmDiscovery(): Promise<boolean> {
     const vmDiscoveryStep = await this.setupProgressRepo.findOneByField({

--- a/src/modules/setup/infrastructure/repositories/setup.typeorm.repository.ts
+++ b/src/modules/setup/infrastructure/repositories/setup.typeorm.repository.ts
@@ -22,12 +22,18 @@ export class SetupProgressRepository
     );
   }
 
+  /**
+   * Retrieve all setup progress records sorted by completion date.
+   */
   findAll(relations?: string[]): Promise<SetupProgress[]> {
     return this.setupProgressRepository.find({
       relations: relations || [],
       order: { completedAt: 'ASC' },
     });
   }
+  /**
+   * Find a single setup progress record by a given field.
+   */
   async findOneByField<K extends keyof SetupProgress>({
     field,
     value,
@@ -48,12 +54,18 @@ export class SetupProgressRepository
     }
   }
 
+  /**
+   * Retrieve the progress record for a specific setup step.
+   */
   async findByStep(step: SetupStep): Promise<SetupProgress | null> {
     return this.setupProgressRepository.findOne({
       where: { step },
     });
   }
 
+  /**
+   * Check whether a given setup step has already been completed.
+   */
   async hasCompletedStep(step: SetupStep): Promise<boolean> {
     const count = await this.setupProgressRepository.count({
       where: { step },
@@ -61,6 +73,9 @@ export class SetupProgressRepository
     return count > 0;
   }
 
+  /**
+   * Get all completed setup steps ordered chronologically.
+   */
   async findAllCompletedSteps(): Promise<SetupProgress[]> {
     return this.setupProgressRepository.find({
       order: { completedAt: 'ASC' },


### PR DESCRIPTION
## Summary
- clarify SetupProgress repository methods
- document SetupProgress mapper methods
- add descriptions for VM discovery use case
- document completion logic for setup step use case
- describe VM discovery check logic in status use case

## Testing
- `pnpm lint`
- `pnpm test` *(fails: this.setupProgressRepo.findOneByField is not a function)*