### PR TITLE
fix/unit-tests-setup: repair setup-related tests

### DIFF
--- a/src/modules/servers/application/use-cases/__tests__/create-server.use-case.spec.ts
+++ b/src/modules/servers/application/use-cases/__tests__/create-server.use-case.spec.ts
@@ -241,13 +241,13 @@ describe('CreateServerUseCase', () => {
       ip: '10.0.0.1',
     });
     // Simule un user AVEC roleId
-    const mockUser = { id: 'user-123', roleId: 'role-42' };
+    const mockUser = createMockUser({ id: 'user-123', roleId: 'role-42' });
 
     roomRepo.findRoomById.mockResolvedValue(mockRoom());
     groupRepo.findOneByField.mockResolvedValue(createMockGroupServer());
     iloUseCase.execute.mockResolvedValue(mockIloDto);
     repo.save.mockResolvedValue(mockServer);
-    userRepo.findOneByField.mockResolvedValue(createMockUser());
+    userRepo.findOneByField.mockResolvedValue(mockUser);
     permissionRepo.createPermission = jest.fn();
 
     await useCase.execute(dto, mockPayload.userId);
@@ -276,7 +276,9 @@ describe('CreateServerUseCase', () => {
     groupRepo.findOneByField.mockResolvedValue(createMockGroupServer());
     iloUseCase.execute.mockResolvedValue(mockIloDto);
     repo.save.mockResolvedValue(mockServer);
-    userRepo.findOneByField.mockResolvedValue(createMockUser());
+    userRepo.findOneByField.mockResolvedValue(
+      createMockUser({ roleId: undefined, role: undefined }),
+    );
     permissionRepo.createPermission = jest.fn();
 
     await useCase.execute(dto, mockPayload.userId);

--- a/src/modules/setup/application/controllers/__tests__/setup.controller.spec.ts
+++ b/src/modules/setup/application/controllers/__tests__/setup.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SetupController } from '../setup.controller';
-import { GetSetupStatusUseCase } from '../../use-cases';
+import { GetSetupStatusUseCase, CompleteVmDiscoveryUseCase } from '../../use-cases';
 
 describe('SetupController', () => {
   let controller: SetupController;
@@ -28,6 +28,10 @@ describe('SetupController', () => {
         {
           provide: GetSetupStatusUseCase,
           useValue: useCaseMock,
+        },
+        {
+          provide: CompleteVmDiscoveryUseCase,
+          useValue: { execute: jest.fn() },
         },
       ],
     }).compile();

--- a/src/modules/setup/application/mappers/setup-status.mapper.ts
+++ b/src/modules/setup/application/mappers/setup-status.mapper.ts
@@ -49,8 +49,7 @@ export class SetupStatusMapper {
     dto.hasUps = counts.upsCount > 0;
     dto.hasServers = counts.serverCount > 0;
 
-    dto.isFirstSetup =
-      setupState.phase === SetupPhase.NOT_STARTED || counts.userCount === 0;
+    dto.isFirstSetup = counts.serverCount === 0 && counts.userCount <= 1;
 
     dto.currentStep = this.mapNextStepToSetupStep(setupState.nextRequiredStep);
 

--- a/src/modules/setup/application/use-cases/__tests__/get-setup-status.use-case.spec.ts
+++ b/src/modules/setup/application/use-cases/__tests__/get-setup-status.use-case.spec.ts
@@ -9,7 +9,7 @@ describe('GetSetupStatusUseCase', () => {
   const roomRepo = { count: jest.fn() };
   const upsRepo = { count: jest.fn() };
   const serverRepo = { count: jest.fn() };
-  const setupprogressRepo = {};
+  const setupprogressRepo = { findOneByField: jest.fn() };
 
   const setupDomainService = {
     determineSetupState: jest.fn(),
@@ -67,6 +67,7 @@ describe('GetSetupStatusUseCase', () => {
       0,
       0,
       0,
+      false,
     );
     expect(setupStatusMapper.toDto).toHaveBeenCalledWith(
       setupState,
@@ -77,6 +78,7 @@ describe('GetSetupStatusUseCase', () => {
         serverCount: 0,
       },
       undefined,
+      false,
     );
 
     expect(result).toBe(expectedDto);
@@ -166,6 +168,7 @@ describe('GetSetupStatusUseCase', () => {
     expect(setupStatusMapper.toDto).toHaveBeenCalledWith(
       setupState,
       expect.objectContaining({ serverCount: 0 }),
+      false,
       false,
     );
   });

--- a/src/modules/setup/domain/services/__tests__/setup.domain.service.spec.ts
+++ b/src/modules/setup/domain/services/__tests__/setup.domain.service.spec.ts
@@ -28,7 +28,7 @@ describe('SetupDomainService', () => {
     });
 
     it('should return COMPLETED if at least one server is present', () => {
-      const result = service.determineSetupState(3, 2, 2, 1);
+      const result = service.determineSetupState(3, 2, 2, 1, true);
 
       expect(result.phase).toBe(SetupPhase.COMPLETED);
       expect(result.hasAdminUser).toBe(true);


### PR DESCRIPTION
## Summary
- repair `CreateServerUseCase` permission assertions
- fix mapper's first setup logic
- update setup status spec expectations
- stub complete VM discovery use case in controller test
- adjust domain service test to include VM discovery flag

## Testing
- `pnpm test`