### PR TITLE
Add dashboard unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infra-control",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/modules/dashboard/application/controllers/__tests__/dashboard.controller.spec.ts
+++ b/src/modules/dashboard/application/controllers/__tests__/dashboard.controller.spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardController } from '../dashboard.controller';
+import { GetDashboardFullStatsUseCase } from '../../use-cases';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+  const getStats = { execute: jest.fn() } as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DashboardController],
+      providers: [{ provide: GetDashboardFullStatsUseCase, useValue: getStats }],
+    }).compile();
+
+    controller = module.get(DashboardController);
+  });
+
+  it('returns dashboard stats', async () => {
+    getStats.execute.mockResolvedValue({ totalUsers: 1 });
+    const result = await controller.getFullDashboard();
+    expect(getStats.execute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ totalUsers: 1 });
+  });
+});

--- a/src/modules/dashboard/application/use-cases/__tests__/get-dashboard-full-stats.use-case.spec.ts
+++ b/src/modules/dashboard/application/use-cases/__tests__/get-dashboard-full-stats.use-case.spec.ts
@@ -1,0 +1,114 @@
+import { GetDashboardFullStatsUseCase } from '../get-dashboard-full-stats.use-case';
+import { SetupStep } from '@/modules/setup/application/dto';
+import { SetupProgress } from '@/modules/setup/domain/entities/setup-progress.entity';
+
+describe('GetDashboardFullStatsUseCase', () => {
+  const statisticsPort = { getStatistics: jest.fn() } as any;
+  const presenceService = { getConnectedUserCount: jest.fn() } as any;
+  const serverRepo = { findAll: jest.fn() } as any;
+  const vmRepo = { findAll: jest.fn() } as any;
+  const progressRepo = { findAll: jest.fn() } as any;
+  let useCase: GetDashboardFullStatsUseCase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCase = new GetDashboardFullStatsUseCase(
+      statisticsPort,
+      presenceService,
+      serverRepo,
+      vmRepo,
+      progressRepo,
+    );
+  });
+
+  it('computes stats with no progress', async () => {
+    statisticsPort.getStatistics.mockResolvedValue({
+      totalUsers: 10,
+      adminUsers: 1,
+      totalRooms: 5,
+      totalUps: 3,
+      totalServers: 2,
+      totalVms: 3,
+    });
+    presenceService.getConnectedUserCount.mockResolvedValue(5);
+    serverRepo.findAll.mockResolvedValue([{ state: 'UP' }, { state: 'DOWN' }]);
+    vmRepo.findAll.mockResolvedValue([
+      { state: 'UP' },
+      { state: 'UP' },
+      { state: 'DOWN' },
+    ]);
+    progressRepo.findAll.mockResolvedValue([]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({
+      totalUsers: 10,
+      adminUsers: 1,
+      totalRooms: 5,
+      totalUps: 3,
+      totalServers: 2,
+      totalVms: 3,
+      serversUp: 1,
+      serversDown: 1,
+      vmsUp: 2,
+      vmsDown: 1,
+      setupComplete: false,
+      setupProgress: 0,
+      onlineUsers: 5,
+    });
+  });
+
+  it('computes progress percentage', async () => {
+    statisticsPort.getStatistics.mockResolvedValue({
+      totalUsers: 10,
+      adminUsers: 1,
+      totalRooms: 5,
+      totalUps: 3,
+      totalServers: 3,
+      totalVms: 2,
+    });
+    presenceService.getConnectedUserCount.mockResolvedValue(2);
+    serverRepo.findAll.mockResolvedValue([
+      { state: 'UP' },
+      { state: 'DOWN' },
+      { state: 'DOWN' },
+    ]);
+    vmRepo.findAll.mockResolvedValue([{ state: 'UP' }, { state: 'UP' }]);
+    progressRepo.findAll.mockResolvedValue([
+      { step: SetupStep.WELCOME } as SetupProgress,
+      { step: SetupStep.CREATE_SERVER } as SetupProgress,
+      { step: SetupStep.CREATE_ROOM } as SetupProgress,
+    ]);
+
+    const result = await useCase.execute();
+
+    expect(result.setupProgress).toBe(60);
+    expect(result.setupComplete).toBe(false);
+    expect(result.serversDown).toBe(2);
+    expect(result.vmsDown).toBe(0);
+    expect(result.onlineUsers).toBe(2);
+  });
+
+  it('marks setup as complete when complete step found', async () => {
+    statisticsPort.getStatistics.mockResolvedValue({
+      totalUsers: 1,
+      adminUsers: 1,
+      totalRooms: 1,
+      totalUps: 1,
+      totalServers: 1,
+      totalVms: 1,
+    });
+    presenceService.getConnectedUserCount.mockResolvedValue(0);
+    serverRepo.findAll.mockResolvedValue([{ state: 'UP' }]);
+    vmRepo.findAll.mockResolvedValue([{ state: 'UP' }]);
+    progressRepo.findAll.mockResolvedValue([
+      { step: SetupStep.WELCOME } as SetupProgress,
+      { step: SetupStep.COMPLETE } as SetupProgress,
+    ]);
+
+    const result = await useCase.execute();
+
+    expect(result.setupComplete).toBe(true);
+    expect(result.setupProgress).toBe(40);
+  });
+});

--- a/src/modules/dashboard/application/use-cases/__tests__/get-setup-statistics.use-case.spec.ts
+++ b/src/modules/dashboard/application/use-cases/__tests__/get-setup-statistics.use-case.spec.ts
@@ -1,0 +1,13 @@
+import { GetSetupStatisticsUseCase } from '../get-setup-statistics.use-case';
+
+describe('GetSetupStatisticsUseCase', () => {
+  it('delegates to StatisticsPort', async () => {
+    const port = { getStatistics: jest.fn().mockResolvedValue({ totalUsers: 1 }) } as any;
+    const useCase = new GetSetupStatisticsUseCase(port);
+
+    const result = await useCase.execute();
+
+    expect(port.getStatistics).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ totalUsers: 1 });
+  });
+});

--- a/src/modules/dashboard/infrastructure/adapters/__tests__/setup-statistics.adapter.spec.ts
+++ b/src/modules/dashboard/infrastructure/adapters/__tests__/setup-statistics.adapter.spec.ts
@@ -1,0 +1,40 @@
+import { SetupStatisticsAdapter } from '../setup-statistics.adapters';
+
+describe('SetupStatisticsAdapter', () => {
+  const userRepo = { count: jest.fn() } as any;
+  const roomRepo = { count: jest.fn() } as any;
+  const upsRepo = { count: jest.fn() } as any;
+  const serverRepo = { count: jest.fn() } as any;
+  const vmRepo = { count: jest.fn() } as any;
+  let adapter: SetupStatisticsAdapter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adapter = new SetupStatisticsAdapter(
+      userRepo,
+      roomRepo,
+      upsRepo,
+      serverRepo,
+      vmRepo,
+    );
+  });
+
+  it('aggregates statistics from repositories', async () => {
+    userRepo.count.mockResolvedValue(10);
+    roomRepo.count.mockResolvedValue(2);
+    upsRepo.count.mockResolvedValue(3);
+    serverRepo.count.mockResolvedValue(5);
+    vmRepo.count.mockResolvedValue(20);
+
+    const result = await adapter.getStatistics();
+
+    expect(result).toEqual({
+      totalUsers: 10,
+      adminUsers: 99,
+      totalRooms: 2,
+      totalUps: 3,
+      totalServers: 5,
+      totalVms: 20,
+    });
+  });
+});

--- a/src/modules/presence/application/services/__tests__/presence.service.spec.ts
+++ b/src/modules/presence/application/services/__tests__/presence.service.spec.ts
@@ -49,4 +49,11 @@ describe('PresenceService', () => {
       60,
     );
   });
+
+  it('should count connected users', async () => {
+    redisSafeService.keys = jest.fn().mockResolvedValue(['presence:u1', 'presence:u2']);
+    const count = await service.getConnectedUserCount();
+    expect(redisSafeService.keys).toHaveBeenCalledWith('presence:*');
+    expect(count).toBe(2);
+  });
 });

--- a/src/modules/redis/application/services/__tests__/redis-safe.service.spec.ts
+++ b/src/modules/redis/application/services/__tests__/redis-safe.service.spec.ts
@@ -50,4 +50,18 @@ describe('RedisSafeService', () => {
     const result = await service.keys('pattern');
     expect(result).toEqual([]);
   });
+
+  it('keys returns results when client available', async () => {
+    client.keys = jest.fn().mockResolvedValue(['a', 'b']);
+    const result = await service.keys('p:*');
+    expect(client.keys).toHaveBeenCalledWith('p:*');
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  it('keys handles redis error gracefully', async () => {
+    client.keys = jest.fn().mockRejectedValue(new Error('oops'));
+    const result = await service.keys('p:*');
+    expect(service.isOnline()).toBe(false);
+    expect(result).toEqual([]);
+  });
 });

--- a/src/modules/vms/infrastructure/repositories/vm.typeorm.repository.spec.ts
+++ b/src/modules/vms/infrastructure/repositories/vm.typeorm.repository.spec.ts
@@ -1,0 +1,50 @@
+import { VmTypeormRepository } from './vm.typeorm.repository';
+import { Repository } from 'typeorm';
+import { Vm } from '../../domain/entities/vm.entity';
+import { VmRetrievalException } from '../../domain/exceptions/vm.exception';
+
+describe('VmTypeormRepository findOneByField', () => {
+  let repo: VmTypeormRepository;
+  let ormRepo: jest.Mocked<Repository<Vm>>;
+
+  beforeEach(() => {
+    ormRepo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<Repository<Vm>>;
+    repo = new VmTypeormRepository({ createEntityManager: () => ormRepo } as any);
+    (repo as any).findOne = ormRepo.findOne;
+  });
+
+  it('returns entity when found', async () => {
+    const vm = { id: '1' } as Vm;
+    ormRepo.findOne.mockResolvedValue(vm);
+    const result = await repo.findOneByField({ field: 'id', value: '1' });
+    expect(ormRepo.findOne).toHaveBeenCalled();
+    expect(result).toBe(vm);
+  });
+
+  it('throws on invalid value', () => {
+    expect(() =>
+      repo.findOneByField({ field: 'id', value: undefined as any }),
+    ).toThrow(/Invalid query value/);
+  });
+
+  it('returns null when error and disableThrow true', async () => {
+    ormRepo.findOne.mockRejectedValue(new Error('db fail'));
+    const result = await repo.findOneByField({
+      field: 'id',
+      value: 'x',
+      disableThrow: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('throws VmRetrievalException when error occurs', async () => {
+    ormRepo.findOne.mockRejectedValue(new Error('oops'));
+    await expect(
+      repo.findOneByField({ field: 'id', value: 'x' }),
+    ).rejects.toThrow(VmRetrievalException);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for dashboard use cases and adapter
- cover new methods in presence and redis services
- create vm repository test
- bump package version to 0.6.0

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68557e5666a8832d88a28818e5d6ec32