### PR TITLE
chore: excludes test and module files from coverage reports

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,3 +16,4 @@ sonar.sources=src
 sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts,**/*.test.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.coverage.exclusions=**/*.spec.ts,**/*.test.ts,**/*.module.ts,**/__mocks__/**,**/*.mock.ts,main.ts,**/core/config/**,**/core/filters/**,**/core/decorators/**,**/core/pipes/**,**/core/utils/**,**/dto/*.ts,src/**/*.interface.ts,src/**/*.entity.ts


### PR DESCRIPTION
Reduces noise in coverage reports by excluding
testing files, module files, mock files, and
specific directories containing configuration,
filters, decorators, pipes and utilities. It also
excludes DTOs, interfaces and entities as they
mostly contain data structures and not logic.
