### PR TITLE
feat(pagination): add generic DTO and paginated UPS

### DIFF
--- a/src/core/dto/index.ts
+++ b/src/core/dto/index.ts
@@ -1,0 +1,1 @@
+export { PaginatedResponseDto } from './paginated-response.dto';

--- a/src/core/dto/paginated-response.dto.ts
+++ b/src/core/dto/paginated-response.dto.ts
@@ -1,0 +1,44 @@
+import { IsArray, IsNumber, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Generic paginated response wrapper.
+ *
+ * @typeParam T - DTO type for each item
+ */
+export class PaginatedResponseDto<T> {
+  /** Items on the current page */
+  @ApiProperty({ isArray: true })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Object)
+  readonly items: T[];
+
+  /** Total item count */
+  @ApiProperty()
+  @IsNumber()
+  readonly totalItems: number;
+
+  /** Total number of pages */
+  @ApiProperty()
+  @IsNumber()
+  readonly totalPages: number;
+
+  /** Current page index */
+  @ApiProperty()
+  @IsNumber()
+  readonly currentPage: number;
+
+  constructor(
+    items: T[],
+    totalItems: number,
+    currentPage: number,
+    pageSize: number,
+  ) {
+    this.items = items;
+    this.totalItems = totalItems;
+    this.currentPage = currentPage;
+    this.totalPages = Math.ceil(totalItems / pageSize);
+  }
+}

--- a/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
+++ b/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
@@ -3,6 +3,7 @@ import { UpsController } from '../ups.controller';
 import { CreateUpsUseCase } from '@/modules/ups/application/use-cases/create-ups.use-case';
 import { DeleteUpsUseCase } from '@/modules/ups/application/use-cases/delete-ups.use-case';
 import { GetAllUpsUseCase } from '@/modules/ups/application/use-cases/get-all-ups.use-case';
+import { GetUpsListUseCase } from '@/modules/ups/application/use-cases/get-ups-list.use-case';
 import { GetUpsByIdUseCase } from '@/modules/ups/application/use-cases/get-ups-by-id.use-case';
 import { UpdateUpsUseCase } from '@/modules/ups/application/use-cases/update-ups.use-case';
 import {
@@ -14,6 +15,7 @@ import { UpsResponseDto } from '../../dto/ups.response.dto';
 describe('UpsController', () => {
   let controller: UpsController;
   let getAllUseCase: jest.Mocked<GetAllUpsUseCase>;
+  let getListUseCase: jest.Mocked<GetUpsListUseCase>;
   let getByIdUseCase: jest.Mocked<GetUpsByIdUseCase>;
   let createUseCase: jest.Mocked<CreateUpsUseCase>;
   let updateUseCase: jest.Mocked<UpdateUpsUseCase>;
@@ -21,6 +23,7 @@ describe('UpsController', () => {
 
   beforeEach(async () => {
     getAllUseCase = { execute: jest.fn() } as any;
+    getListUseCase = { execute: jest.fn() } as any;
     getByIdUseCase = { execute: jest.fn() } as any;
     createUseCase = { execute: jest.fn() } as any;
     updateUseCase = { execute: jest.fn() } as any;
@@ -30,6 +33,7 @@ describe('UpsController', () => {
       controllers: [UpsController],
       providers: [
         { provide: GetAllUpsUseCase, useValue: getAllUseCase },
+        { provide: GetUpsListUseCase, useValue: getListUseCase },
         { provide: GetUpsByIdUseCase, useValue: getByIdUseCase },
         { provide: CreateUpsUseCase, useValue: createUseCase },
         { provide: UpdateUpsUseCase, useValue: updateUseCase },
@@ -38,6 +42,14 @@ describe('UpsController', () => {
     }).compile();
 
     controller = module.get<UpsController>(UpsController);
+  });
+
+  it('should return paginated UPS list', async () => {
+    const mock = { items: [new UpsResponseDto(createMockUps())] } as any;
+    getListUseCase.execute.mockResolvedValue(mock);
+    const result = await controller.getUps('1', '5');
+    expect(result).toBe(mock);
+    expect(getListUseCase.execute).toHaveBeenCalledWith(1, 5);
   });
 
   it('should return all UPSs', async () => {

--- a/src/modules/ups/application/controllers/ups.controller.ts
+++ b/src/modules/ups/application/controllers/ups.controller.ts
@@ -7,38 +7,52 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
-import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import {
   CreateUpsUseCase,
   DeleteUpsUseCase,
+  GetUpsListUseCase,
   GetAllUpsUseCase,
   GetUpsByIdUseCase,
   UpdateUpsUseCase,
 } from '@/modules/ups/application/use-cases';
 
 import { UpsResponseDto } from '../dto/ups.response.dto';
-import { UpsCreationDto } from '../dto/ups.creation.dto';
-import { UpsUpdateDto } from '../dto/ups.update.dto';
+import { UpsCreationDto, UpsListResponseDto, UpsUpdateDto } from '../dto';
 
 @ApiTags('UPS')
 @Controller('ups')
 export class UpsController {
   constructor(
     private readonly getAllUpsUseCase: GetAllUpsUseCase,
+    private readonly getUpsListUseCase: GetUpsListUseCase,
     private readonly getUpsByIdUseCase: GetUpsByIdUseCase,
     private readonly createUpsUseCase: CreateUpsUseCase,
     private readonly updateUpsUseCase: UpdateUpsUseCase,
     private readonly deleteUpsUseCase: DeleteUpsUseCase,
   ) {}
 
-  @Get()
-  @ApiOperation({
-    summary: 'Lister tous les équipements UPS',
-    description:
-      'Renvoie la liste complète de tous les équipements UPS disponibles.',
-  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOperation({ summary: 'Lister les UPS paginés' })
+  async getUps(
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+  ): Promise<UpsListResponseDto> {
+    return this.getUpsListUseCase.execute(Number(page), Number(limit));
+  }
+
+  @Get('all')
+  @ApiOperation({ summary: 'Lister tous les équipements UPS' })
   async getAllUps(): Promise<UpsResponseDto[]> {
     return this.getAllUpsUseCase.execute();
   }

--- a/src/modules/ups/application/dto/index.ts
+++ b/src/modules/ups/application/dto/index.ts
@@ -1,0 +1,6 @@
+import { UpsCreationDto } from './ups.creation.dto';
+import { UpsListResponseDto } from './ups.list.response.dto';
+import { UpsResponseDto } from './ups.response.dto';
+import { UpsUpdateDto } from './ups.update.dto';
+
+export { UpsCreationDto, UpsListResponseDto, UpsResponseDto, UpsUpdateDto };

--- a/src/modules/ups/application/use-cases/__tests__/get-ups-list.use-case.spec.ts
+++ b/src/modules/ups/application/use-cases/__tests__/get-ups-list.use-case.spec.ts
@@ -1,0 +1,36 @@
+import { GetUpsListUseCase } from '../get-ups-list.use-case';
+import { UpsRepositoryInterface } from '@/modules/ups/domain/interfaces/ups.repository.interface';
+import { createMockUps } from '@/modules/ups/__mocks__/ups.mock';
+
+describe('GetUpsListUseCase', () => {
+  let useCase: GetUpsListUseCase;
+  let repo: jest.Mocked<UpsRepositoryInterface>;
+
+  beforeEach(() => {
+    repo = {
+      paginate: jest.fn(),
+    } as any;
+    useCase = new GetUpsListUseCase(repo);
+  });
+
+  it('should return paginated UPS list', async () => {
+    const upsList = [createMockUps({ id: 'ups-1' })];
+    repo.paginate.mockResolvedValue([upsList, 1]);
+
+    const result = await useCase.execute(2, 5);
+
+    expect(repo.paginate).toHaveBeenCalledWith(2, 5);
+    expect(result.items).toHaveLength(1);
+    expect(result.totalItems).toBe(1);
+    expect(result.currentPage).toBe(2);
+  });
+
+  it('should return empty list when no UPS found', async () => {
+    repo.paginate.mockResolvedValue([[], 0]);
+
+    const result = await useCase.execute();
+
+    expect(result.items).toEqual([]);
+    expect(result.totalItems).toBe(0);
+  });
+});

--- a/src/modules/ups/application/use-cases/get-ups-list.use-case.ts
+++ b/src/modules/ups/application/use-cases/get-ups-list.use-case.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.interface';
+import { UpsResponseDto } from '../dto/ups.response.dto';
+import { UpsListResponseDto } from '../dto';
+
+@Injectable()
+export class GetUpsListUseCase {
+  constructor(
+    @Inject('UpsRepositoryInterface')
+    private readonly repo: UpsRepositoryInterface,
+  ) {}
+
+  /**
+   * Retrieve a paginated list of UPS.
+   *
+   * @param page - page number starting at 1
+   * @param limit - number of UPS per page
+   */
+  async execute(page = 1, limit = 10): Promise<UpsListResponseDto> {
+    const [ups, total] = await this.repo.paginate(page, limit);
+    const dtos = ups.map((u) => new UpsResponseDto(u));
+    return new UpsListResponseDto(dtos, total, page, limit);
+  }
+}

--- a/src/modules/ups/application/use-cases/index.ts
+++ b/src/modules/ups/application/use-cases/index.ts
@@ -2,11 +2,13 @@ import { CreateUpsUseCase } from './create-ups.use-case';
 import { DeleteUpsUseCase } from './delete-ups.use-case';
 import { GetAllUpsUseCase } from './get-all-ups.use-case';
 import { GetUpsByIdUseCase } from './get-ups-by-id.use-case';
+import { GetUpsListUseCase } from './get-ups-list.use-case';
 import { UpdateUpsUseCase } from './update-ups.use-case';
 
 export const UpsUseCases = [
   CreateUpsUseCase,
   GetAllUpsUseCase,
+  GetUpsListUseCase,
   GetUpsByIdUseCase,
   UpdateUpsUseCase,
   DeleteUpsUseCase,
@@ -15,6 +17,7 @@ export const UpsUseCases = [
 export {
   CreateUpsUseCase,
   GetAllUpsUseCase,
+  GetUpsListUseCase,
   GetUpsByIdUseCase,
   UpdateUpsUseCase,
   DeleteUpsUseCase,

--- a/src/modules/ups/domain/interfaces/ups.repository.interface.ts
+++ b/src/modules/ups/domain/interfaces/ups.repository.interface.ts
@@ -6,4 +6,12 @@ export interface UpsRepositoryInterface
   findUpsById(id: string): Promise<Ups | null>;
   updateUps(ups: Ups): Promise<Ups>;
   deleteUps(id: string): Promise<void>;
+  /**
+   * Retrieve UPS entities with pagination.
+   *
+   * @param page - page number starting at 1
+   * @param limit - number of items per page
+   * @returns tuple of entities and total count
+   */
+  paginate(page: number, limit: number): Promise<[Ups[], number]>;
 }

--- a/src/modules/ups/infrastructure/repositories/ups.typeorm.repository.ts
+++ b/src/modules/ups/infrastructure/repositories/ups.typeorm.repository.ts
@@ -49,6 +49,21 @@ export class UpsTypeormRepository
     }
   }
 
+  /**
+   * Paginate UPS entities.
+   *
+   * @param page - page number starting at 1
+   * @param limit - items per page
+   */
+  async paginate(page: number, limit: number): Promise<[Ups[], number]> {
+    return this.findAndCount({
+      relations: ['servers'],
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { name: 'ASC' },
+    });
+  }
+
   async findUpsById(id: string): Promise<Ups> {
     try {
       return await this.findOneOrFail({

--- a/src/modules/users/application/controllers/user.controller.spec.ts
+++ b/src/modules/users/application/controllers/user.controller.spec.ts
@@ -4,6 +4,8 @@ import { UserController } from './user.controller';
 import { GetMeUseCase } from '../use-cases/get-me.use-case';
 import { GetUserByIdUseCase } from '../use-cases/get-user-by-id.use-case';
 import { GetUserListUseCase } from '../use-cases/get-user-list.use-case';
+import { GetUserCountUseCase } from '../use-cases/get-user-count.use-case';
+
 import { UpdateUserUseCase } from '../use-cases/update-user.use-case';
 import { ResetPasswordUseCase } from '../use-cases/reset-password.use-case';
 import { DeleteUserUseCase } from '../use-cases/delete-user.use-case';
@@ -27,6 +29,8 @@ describe('UserController', () => {
   const getMeUseCase = { execute: jest.fn() };
   const getUserByIdUseCase = { execute: jest.fn() };
   const getUserListUseCase = { execute: jest.fn() };
+  const getUserCountUseCase = { execute: jest.fn() };
+
   const updateUserUseCase = { execute: jest.fn() };
   const resetPasswordUseCase = { execute: jest.fn() };
   const deleteUserUseCase = { execute: jest.fn() };
@@ -39,6 +43,8 @@ describe('UserController', () => {
         { provide: GetMeUseCase, useValue: getMeUseCase },
         { provide: GetUserByIdUseCase, useValue: getUserByIdUseCase },
         { provide: GetUserListUseCase, useValue: getUserListUseCase },
+        { provide: GetUserCountUseCase, useValue: getUserCountUseCase },
+
         { provide: UpdateUserUseCase, useValue: updateUserUseCase },
         { provide: ResetPasswordUseCase, useValue: resetPasswordUseCase },
         { provide: DeleteUserUseCase, useValue: deleteUserUseCase },
@@ -72,7 +78,12 @@ describe('UserController', () => {
 
   describe('getUsers', () => {
     it('should return paginated users', async () => {
-      const paginated = { items: [], totalItems: 0, totalPages: 0, currentPage: 1 };
+      const paginated = {
+        items: [],
+        totalItems: 0,
+        totalPages: 0,
+        currentPage: 1,
+      };
       getUserListUseCase.execute.mockResolvedValue(paginated as any);
 
       const result = await controller.getUsers('1', '10');
@@ -102,6 +113,15 @@ describe('UserController', () => {
       getUserListUseCase.execute.mockRejectedValue(new Error('oops'));
 
       await expect(controller.getUsers('2', '5')).rejects.toThrow('oops');
+    });
+  });
+
+  describe('getUserCount', () => {
+    it('should return total users count', async () => {
+      getUserCountUseCase.execute.mockResolvedValue(42);
+      const result = await controller.getUserCount();
+      expect(getUserCountUseCase.execute).toHaveBeenCalled();
+      expect(result).toBe(42);
     });
   });
 

--- a/src/modules/users/application/controllers/user.controller.ts
+++ b/src/modules/users/application/controllers/user.controller.ts
@@ -30,6 +30,7 @@ import { UserUpdateDto } from '../dto/user.update.dto';
 import {
   GetMeUseCase,
   GetUserByIdUseCase,
+  GetUserCountUseCase,
   GetUserListUseCase,
   UpdateUserUseCase,
   DeleteUserUseCase,
@@ -44,6 +45,7 @@ export class UserController {
     private readonly getMeUseCase: GetMeUseCase,
     private readonly getUserByIdUseCase: GetUserByIdUseCase,
     private readonly getUserListUseCase: GetUserListUseCase,
+    private readonly getUserCountUseCase: GetUserCountUseCase,
     private readonly updateUserUseCase: UpdateUserUseCase,
     private readonly resetPasswordUseCase: ResetPasswordUseCase,
     private readonly deleteUserUseCase: DeleteUserUseCase,
@@ -72,6 +74,17 @@ export class UserController {
     @Query('limit') limit = '10',
   ): Promise<UserListResponseDto> {
     return this.getUserListUseCase.execute(Number(page), Number(limit));
+  }
+
+  /**
+   * Get total count of users.
+   */
+  @Get('count')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Nombre total d'utilisateurs" })
+  async getUserCount(): Promise<number> {
+    return this.getUserCountUseCase.execute();
   }
 
   @Get(':id')

--- a/src/modules/users/application/dto/user.list.response.dto.ts
+++ b/src/modules/users/application/dto/user.list.response.dto.ts
@@ -1,26 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsNumber, ValidateNested } from 'class-validator';
+import { IsArray, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { UserResponseDto } from './user.response.dto';
+import { PaginatedResponseDto } from '@/core/dto';
 
-export class UserListResponseDto {
+export class UserListResponseDto extends PaginatedResponseDto<UserResponseDto> {
   @ApiProperty({ type: () => UserResponseDto, isArray: true })
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => UserResponseDto)
   readonly items: UserResponseDto[];
-
-  @ApiProperty()
-  @IsNumber()
-  readonly totalItems: number;
-
-  @ApiProperty()
-  @IsNumber()
-  readonly totalPages: number;
-
-  @ApiProperty()
-  @IsNumber()
-  readonly currentPage: number;
 
   constructor(
     items: UserResponseDto[],
@@ -28,9 +17,6 @@ export class UserListResponseDto {
     currentPage: number,
     pageSize: number,
   ) {
-    this.items = items;
-    this.totalItems = totalItems;
-    this.currentPage = currentPage;
-    this.totalPages = Math.ceil(totalItems / pageSize);
+    super(items, totalItems, currentPage, pageSize);
   }
 }


### PR DESCRIPTION
Introduces a generic paginated response DTO to standardize paginated API responses.

- Implements the `PaginatedResponseDto` for consistent data structuring across modules.
- Adds paginated list functionality to the UPS module, including a new use case and controller endpoint.
- Modifies the User module to leverage the generic `PaginatedResponseDto`.