### PR TITLE
feat/migrations: add production migration setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "NODE_OPTIONS='-r tsconfig-paths/register' jest --config ./test/jest-e2e.json"
+    "test:e2e": "NODE_OPTIONS='-r tsconfig-paths/register' jest --config ./test/jest-e2e.json",
+    "migration:generate": "ts-node ./node_modules/typeorm/cli.js -d src/core/config/data-source.ts migration:generate",
+    "migration:run": "ts-node ./node_modules/typeorm/cli.js -d dist/core/config/data-source.js migration:run"
   },
   "dependencies": {
     "@liaoliaots/nestjs-redis": "^10.0.0",

--- a/src/core/config/__tests__/data-source.spec.ts
+++ b/src/core/config/__tests__/data-source.spec.ts
@@ -1,0 +1,23 @@
+import { AppDataSource } from '../data-source';
+import * as config from '../typeorm.config';
+
+describe('AppDataSource', () => {
+  it('creates DataSource with options from buildTypeOrmOptions', () => {
+    jest.spyOn(config, 'buildTypeOrmOptions').mockReturnValue({
+      type: 'postgres',
+      host: 'h',
+      port: 5432,
+      database: 'd',
+      username: 'u',
+      password: 'p',
+      entities: [],
+      migrations: [],
+      synchronize: false,
+      migrationsRun: true,
+      logging: false,
+      autoLoadEntities: true,
+    });
+    expect(AppDataSource.options.type).toBe('postgres');
+    expect((AppDataSource.options as any).autoLoadEntities).toBeUndefined();
+  });
+});

--- a/src/core/config/__tests__/typeorm.config.spec.ts
+++ b/src/core/config/__tests__/typeorm.config.spec.ts
@@ -1,0 +1,35 @@
+import { buildTypeOrmOptions } from '../typeorm.config';
+
+describe('buildTypeOrmOptions', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV,
+      DB_HOST: 'host',
+      DB_PORT: '5432',
+      DB_NAME: 'db',
+      DB_USERNAME: 'user',
+      DB_PASSWORD: 'pass',
+    };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('returns dev settings', () => {
+    process.env.NODE_ENV = 'development';
+    const options = buildTypeOrmOptions();
+    expect(options.synchronize).toBe(true);
+    expect(options.migrationsRun).toBe(false);
+  });
+
+  it('returns prod settings', () => {
+    process.env.NODE_ENV = 'production';
+    const options = buildTypeOrmOptions();
+    expect(options.synchronize).toBe(false);
+    expect(options.migrationsRun).toBe(true);
+    expect(options.migrations?.length).toBeGreaterThan(0);
+  });
+});

--- a/src/core/config/data-source.ts
+++ b/src/core/config/data-source.ts
@@ -1,0 +1,10 @@
+import { DataSource } from 'typeorm';
+import { buildTypeOrmOptions } from './typeorm.config';
+
+/**
+ * DataSource used by the TypeORM CLI to run migrations.
+ */
+export const AppDataSource = (() => {
+  const { autoLoadEntities, ...options } = buildTypeOrmOptions();
+  return new DataSource(options as any);
+})();

--- a/src/core/config/typeorm.config.ts
+++ b/src/core/config/typeorm.config.ts
@@ -1,15 +1,22 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 
-export const typeOrmConfig: TypeOrmModuleOptions = {
+/**
+ * Build TypeORM options based on environment variables. Synchronization is
+ * disabled in production and migrations are executed automatically.
+ */
+export const buildTypeOrmOptions = (): TypeOrmModuleOptions => ({
   type: 'postgres',
   host: process.env.DB_HOST,
-  port: parseInt(process.env.DB_PORT, 10),
+  port: parseInt(process.env.DB_PORT ?? '5432', 10),
   database: process.env.DB_NAME,
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   entities: [__dirname + '/../modules/**/*.entity{.ts,.js}'],
-  synchronize: true,
-  migrationsRun: false,
+  migrations: [__dirname + '/../migrations/*{.ts,.js}'],
+  synchronize: process.env.NODE_ENV !== 'production',
+  migrationsRun: process.env.NODE_ENV === 'production',
   logging: false,
   autoLoadEntities: true,
-};
+});
+
+export const typeOrmConfig = buildTypeOrmOptions();


### PR DESCRIPTION
## Summary
- support TypeORM migrations with a DataSource
- disable synchronize in production and auto-run migrations
- add migration scripts in package.json
- test buildTypeOrmOptions and DataSource helpers

## Testing
- `pnpm test src/core/config/__tests__/typeorm.config.spec.ts src/core/config/__tests__/data-source.spec.ts`
- `pnpm test` *(fails: GetRoleListUseCase dependency missing)*