### PR TITLE
fix: update presence ttl

### DIFF
--- a/src/modules/presence/application/services/__tests__/presence.service.spec.ts
+++ b/src/modules/presence/application/services/__tests__/presence.service.spec.ts
@@ -22,6 +22,10 @@ describe('PresenceService', () => {
       'presence:user-123',
       'online',
     );
+    expect(redisSafeService.safeExpire).toHaveBeenCalledWith(
+      'presence:user-123',
+      60,
+    );
   });
 
   it('should mark user as offline', async () => {

--- a/src/modules/presence/application/services/presence.service.ts
+++ b/src/modules/presence/application/services/presence.service.ts
@@ -7,6 +7,7 @@ export class PresenceService {
 
   async markOnline(userId: string): Promise<void> {
     await this.redisSafeService.safeSet(`presence:${userId}`, 'online');
+    await this.redisSafeService.safeExpire(`presence:${userId}`, 60);
   }
 
   async markOffline(userId: string): Promise<void> {

--- a/src/modules/roles/application/controllers/__tests__/role.controller.spec.ts
+++ b/src/modules/roles/application/controllers/__tests__/role.controller.spec.ts
@@ -32,6 +32,7 @@ describe('RoleController', () => {
       controllers: [RoleController],
       providers: [
         { provide: CreateRoleUseCase, useValue: createRoleUseCase },
+        { provide: GetRoleListUseCase, useValue: getRoleListUseCase },
         { provide: GetAllRolesUseCase, useValue: getAllRolesUseCase },
         { provide: GetRoleByIdUseCase, useValue: getRoleByIdUseCase },
         { provide: UpdateRoleUseCase, useValue: updateRoleUseCase },


### PR DESCRIPTION
## Summary
- refresh Redis expiration when marking user online
- verify presence TTL in tests
- fix role controller test dependency

## Testing
- `npm test --silent`