### PR TITLE
test/auth-token-flow

### DIFF
--- a/src/modules/auth/application/controllers/auth.controller.spec.ts
+++ b/src/modules/auth/application/controllers/auth.controller.spec.ts
@@ -38,13 +38,30 @@ describe('AuthController', () => {
     controller = module.get<AuthController>(AuthController);
   });
 
-  it('should call login use case with dto', async () => {
+  it('should call login use case with dto and set cookie', async () => {
     const dto: LoginDto = { identifier: 'john', password: 'pass' };
-    await controller.login(dto, {} as any);
+    const res = { cookie: jest.fn() } as any;
+    loginUseCase.execute.mockResolvedValue({
+      accessToken: 'acc',
+      refreshToken: 'ref',
+    });
+
+    const result = await controller.login(dto, res);
+
     expect(loginUseCase.execute).toHaveBeenCalledWith(dto);
+    expect(res.cookie).toHaveBeenCalledWith(
+      'refreshToken',
+      'ref',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'strict',
+        path: '/auth/refresh',
+      }),
+    );
+    expect(result).toEqual({ accessToken: 'acc' });
   });
 
-  it('should call register use case with dto', async () => {
+  it('should call register use case with dto and set cookie', async () => {
     const dto: RegisterDto = {
       firstName: 'John',
       lastName: 'Doe',
@@ -52,8 +69,25 @@ describe('AuthController', () => {
       username: 'johndoe',
       password: 'Password123!',
     };
-    await controller.register(dto, {} as any);
+    const res = { cookie: jest.fn() } as any;
+    registerUseCase.execute.mockResolvedValue({
+      accessToken: 'acc',
+      refreshToken: 'ref',
+    });
+
+    const result = await controller.register(dto, res);
+
     expect(registerUseCase.execute).toHaveBeenCalledWith(dto);
+    expect(res.cookie).toHaveBeenCalledWith(
+      'refreshToken',
+      'ref',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'strict',
+        path: '/auth/refresh',
+      }),
+    );
+    expect(result).toEqual({ accessToken: 'acc' });
   });
 
   it('should call renew token use case with refreshToken from cookie', async () => {

--- a/src/modules/auth/application/use-cases/__tests__/register.use-case.spec.ts
+++ b/src/modules/auth/application/use-cases/__tests__/register.use-case.spec.ts
@@ -29,19 +29,35 @@ describe('RegisterUseCase', () => {
     useCase = new RegisterUseCase(registerUserUseCase, jwtService);
   });
 
-  it('should register a new user and return an access token', async () => {
+  it('should register a new user and return access and refresh tokens', async () => {
     const fakeUser = createMockUser();
     registerUserUseCase.execute.mockResolvedValue(fakeUser);
-    jwtService.sign.mockReturnValue('mock.jwt.token');
+    jwtService.sign
+      .mockReturnValueOnce('access.jwt.token')
+      .mockReturnValueOnce('refresh.jwt.token');
 
     const result = await useCase.execute(mockDto);
 
     expect(registerUserUseCase.execute).toHaveBeenCalledWith(mockDto);
-    expect(jwtService.sign).toHaveBeenCalledWith({
-      email: fakeUser.email,
-      isTwoFactorEnabled: fakeUser.isTwoFactorEnabled,
-      userId: fakeUser.id,
+    expect(jwtService.sign).toHaveBeenCalledWith(
+      {
+        userId: fakeUser.id,
+        email: fakeUser.email,
+        isTwoFactorEnabled: fakeUser.isTwoFactorEnabled,
+      },
+      { expiresIn: '15m' },
+    );
+    expect(jwtService.sign).toHaveBeenCalledWith(
+      {
+        userId: fakeUser.id,
+        email: fakeUser.email,
+        isTwoFactorEnabled: fakeUser.isTwoFactorEnabled,
+      },
+      { expiresIn: '7d' },
+    );
+    expect(result).toEqual({
+      accessToken: 'access.jwt.token',
+      refreshToken: 'refresh.jwt.token',
     });
-    expect(result).toEqual({ accessToken: 'mock.jwt.token' });
   });
 });

--- a/src/modules/auth/application/use-cases/__tests__/renew-token.use-case.spec.ts
+++ b/src/modules/auth/application/use-cases/__tests__/renew-token.use-case.spec.ts
@@ -56,4 +56,12 @@ describe('RenewTokenUseCase', () => {
       refreshToken: 'new.refresh.token',
     });
   });
+
+  it('should throw UnauthorizedException when verification fails', () => {
+    jwtService.verify.mockImplementation(() => {
+      throw new Error('invalid');
+    });
+
+    expect(() => useCase.execute('bad.token')).toThrow('Invalid or expired refresh token');
+  });
 });

--- a/src/modules/auth/infrastructure/guards/__tests__/jwt-auth.guard.spec.ts
+++ b/src/modules/auth/infrastructure/guards/__tests__/jwt-auth.guard.spec.ts
@@ -5,15 +5,13 @@ import { JwtService } from '@nestjs/jwt';
 describe('JwtAuthGuard', () => {
   let guard: JwtAuthGuard;
   let jwtService: jest.Mocked<JwtService>;
-  let response: {
-    setHeader: jest.MockedFunction<(name: string, value: string) => void>;
-  };
+  let response: { setHeader: jest.MockedFunction<(name: string, value: string) => void> };
   let context: ExecutionContext;
   let superHandle: jest.SpyInstance;
 
   beforeEach(() => {
-    jwtService = { sign: jest.fn().mockReturnValue('signed') } as any;
-    guard = new JwtAuthGuard(jwtService);
+    jwtService = { sign: jest.fn() } as any;
+    guard = new JwtAuthGuard();
     response = { setHeader: jest.fn() } as any;
     context = {
       switchToHttp: () => ({ getResponse: () => response }),
@@ -26,26 +24,16 @@ describe('JwtAuthGuard', () => {
     jest.restoreAllMocks();
   });
 
-  it('adds access token header when user exists', () => {
+  it('delegates to super.handleRequest when user exists', () => {
     const user = { userId: '1', email: 'a@test.com' } as any;
     const result = guard.handleRequest(null, user, null, context);
-    expect(jwtService.sign).toHaveBeenCalledWith(
-      {
-        userId: '1',
-        email: 'a@test.com',
-        isTwoFactorEnabled: undefined,
-        role: undefined,
-      },
-      { expiresIn: undefined },
-    );
-    expect(response.setHeader).toHaveBeenCalledWith('x-access-token', 'signed');
+    expect(response.setHeader).not.toHaveBeenCalled();
     expect(superHandle).toHaveBeenCalledWith(null, user, null, context);
     expect(result).toBe('result');
   });
 
-  it('does nothing when user absent', () => {
+  it('delegates to super.handleRequest when user absent', () => {
     const result = guard.handleRequest(null, null as any, null, context);
-    expect(jwtService.sign).not.toHaveBeenCalled();
     expect(response.setHeader).not.toHaveBeenCalled();
     expect(superHandle).toHaveBeenCalledWith(null, null, null, context);
     expect(result).toBe('result');


### PR DESCRIPTION
## Summary
- adjust `AuthController` tests for refresh token cookie
- update login & register use case tests to expect refresh tokens
- extend `RenewTokenUseCase` tests with error case
- simplify JwtAuthGuard tests for new behavior

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_685bada295ac832d92b83f43558bca5a