### PR TITLE
feat/ssh: websocket ssh gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "speakeasy": "^2.0.0",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.22",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "ssh2": "^1.14.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       speakeasy:
         specifier: ^2.0.0
         version: 2.0.0
+      ssh2:
+        specifier: ^1.14.0
+        version: 1.16.0
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@5.1.0)
@@ -1217,6 +1220,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -1260,6 +1266,9 @@ packages:
   base64id@2.0.0:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   bcryptjs@3.0.2:
     resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
@@ -1309,6 +1318,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.6:
+    resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
+    engines: {node: '>=10.0.0'}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1495,6 +1508,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -2545,6 +2562,9 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  nan@2.22.2:
+    resolution: {integrity: sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -3058,6 +3078,10 @@ packages:
     resolution: {integrity: sha512-+fLpbAbWkQ+d0JEchJT/NrRRXbYRNbG15gFpANx73EwxQB1PRjj+k/OI0GTU0J63g8ikGkJECQp9z8XEJZvPRw==}
     engines: {node: '>=14'}
 
+  ssh2@1.16.0:
+    resolution: {integrity: sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==}
+    engines: {node: '>=10.16.0'}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -3290,6 +3314,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4845,6 +4872,10 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -4912,6 +4943,10 @@ snapshots:
 
   base64id@2.0.0: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   bcryptjs@3.0.2: {}
 
   binary-extensions@2.3.0: {}
@@ -4977,6 +5012,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.6:
+    optional: true
 
   busboy@1.6.0:
     dependencies:
@@ -5146,6 +5184,12 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.8.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.6
+      nan: 2.22.2
+    optional: true
 
   create-jest@29.7.0(@types/node@22.15.17)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.8.3)):
     dependencies:
@@ -6392,6 +6436,9 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
+  nan@2.22.2:
+    optional: true
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -6898,6 +6945,14 @@ snapshots:
 
   sql-highlight@6.0.0: {}
 
+  ssh2@1.16.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.22.2
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -7139,6 +7194,8 @@ snapshots:
   tslib@2.7.0: {}
 
   tslib@2.8.1: {}
+
+  tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { GuardsModule } from './core/guards.module';
 import { SetupModule } from './modules/setup/setup.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { HistoryModule } from './modules/history/history.module';
+import { SshModule } from './modules/ssh';
 
 @Module({
   controllers: [],
@@ -41,6 +42,7 @@ import { HistoryModule } from './modules/history/history.module';
     SetupModule,
     HistoryModule,
     DashboardModule,
+    SshModule,
   ],
   providers: [Logger],
 })

--- a/src/modules/ssh/application/gateway/__tests__/ssh.gateway.spec.ts
+++ b/src/modules/ssh/application/gateway/__tests__/ssh.gateway.spec.ts
@@ -1,0 +1,60 @@
+import { SshGateway } from '../ssh.gateway';
+import { OpenSshSessionUseCase } from '../../use-cases/open-ssh-session.use-case';
+import { Socket } from 'socket.io';
+
+describe('SshGateway', () => {
+  let gateway: SshGateway;
+  let useCase: jest.Mocked<OpenSshSessionUseCase>;
+  let client: Partial<Socket> & { data: any };
+  let shell: any;
+  let sshClient: any;
+
+  beforeEach(() => {
+    shell = {
+      on: jest.fn(),
+      write: jest.fn(),
+      end: jest.fn(),
+    };
+    sshClient = { end: jest.fn() };
+    useCase = { execute: jest.fn().mockResolvedValue({ client: sshClient, shell }) } as any;
+    gateway = new SshGateway(useCase);
+    client = {
+      handshake: { auth: { ip: '1', username: 'u', password: 'p' } },
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+      data: {},
+    } as any;
+  });
+
+  it('should open session on connection and forward data', async () => {
+    let dataCallback: (d: Buffer) => void = () => {};
+    shell.on.mockImplementation((event: string, cb: any) => {
+      if (event === 'data') dataCallback = cb;
+    });
+    await gateway.handleConnection(client as Socket);
+    expect(useCase.execute).toHaveBeenCalledWith({ host: '1', username: 'u', password: 'p' });
+    dataCallback(Buffer.from('hello'));
+    expect(client.emit).toHaveBeenCalledWith('ssh:data', 'hello');
+  });
+
+  it('should send data to shell', () => {
+    client.data.shell = shell;
+    gateway.handleData(client as Socket, 'cmd');
+    expect(shell.write).toHaveBeenCalledWith('cmd');
+  });
+
+  it('should close session on disconnect', () => {
+    client.data.shell = shell;
+    client.data.sshClient = sshClient;
+    gateway.handleDisconnect(client as Socket);
+    expect(shell.end).toHaveBeenCalled();
+    expect(sshClient.end).toHaveBeenCalled();
+  });
+
+  it('should handle connection errors', async () => {
+    useCase.execute.mockRejectedValue(new Error('fail'));
+    await gateway.handleConnection(client as Socket);
+    expect(client.emit).toHaveBeenCalledWith('ssh:error', 'Unable to connect');
+    expect(client.disconnect).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/modules/ssh/application/gateway/ssh.gateway.ts
+++ b/src/modules/ssh/application/gateway/ssh.gateway.ts
@@ -1,0 +1,63 @@
+import {
+  ConnectedSocket,
+  MessageBody,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { ClientChannel, Client } from 'ssh2';
+import { OpenSshSessionUseCase } from '../use-cases/open-ssh-session.use-case';
+
+@WebSocketGateway({ cors: true, namespace: '/ssh' })
+export class SshGateway {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(private readonly openSession: OpenSshSessionUseCase) {}
+
+  async handleConnection(client: Socket): Promise<void> {
+    const { ip, username, password } = client.handshake.auth as Record<
+      string,
+      string
+    >;
+    try {
+      const { client: sshClient, shell } = await this.openSession.execute({
+        host: ip,
+        username,
+        password,
+      });
+      client.data.sshClient = sshClient;
+      client.data.shell = shell;
+      console.log(`SSH connection established for ${username}@${ip}`);
+
+      shell.on('data', (data: Buffer) => {
+        client.emit('ssh:data', data.toString());
+      });
+      shell.on('close', () => {
+        client.emit('ssh:close');
+        client.disconnect(true);
+      });
+    } catch (err) {
+      console.error('SSH connection error:', err);
+      client.emit('ssh:error', 'Unable to connect');
+      client.disconnect(true);
+    }
+  }
+
+  handleDisconnect(@ConnectedSocket() client: Socket): void {
+    const shell: ClientChannel | undefined = client.data.shell;
+    const sshClient: Client | undefined = client.data.sshClient;
+    shell?.end();
+    sshClient?.end();
+  }
+
+  @SubscribeMessage('ssh:data')
+  handleData(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: string,
+  ): void {
+    const shell: ClientChannel | undefined = client.data.shell;
+    shell?.write(payload);
+  }
+}

--- a/src/modules/ssh/application/use-cases/__tests__/open-ssh-session.use-case.spec.ts
+++ b/src/modules/ssh/application/use-cases/__tests__/open-ssh-session.use-case.spec.ts
@@ -1,0 +1,12 @@
+import { OpenSshSessionUseCase } from '../open-ssh-session.use-case';
+import { SshService } from '../../../domain/services/ssh.service';
+
+describe('OpenSshSessionUseCase', () => {
+  it('should delegate to SshService', async () => {
+    const sshService = { createSession: jest.fn().mockResolvedValue('session') } as unknown as SshService;
+    const useCase = new OpenSshSessionUseCase(sshService);
+    const result = await useCase.execute({ host: 'h', username: 'u', password: 'p' });
+    expect(sshService.createSession).toHaveBeenCalledWith({ host: 'h', username: 'u', password: 'p' });
+    expect(result).toBe('session');
+  });
+});

--- a/src/modules/ssh/application/use-cases/open-ssh-session.use-case.ts
+++ b/src/modules/ssh/application/use-cases/open-ssh-session.use-case.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { SshService, SshSession } from '../../domain/services/ssh.service';
+
+@Injectable()
+export class OpenSshSessionUseCase {
+  constructor(private readonly sshService: SshService) {}
+
+  execute(options: {
+    host: string;
+    username: string;
+    password: string;
+  }): Promise<SshSession> {
+    return this.sshService.createSession(options);
+  }
+}

--- a/src/modules/ssh/domain/services/__tests__/ssh.service.spec.ts
+++ b/src/modules/ssh/domain/services/__tests__/ssh.service.spec.ts
@@ -1,0 +1,48 @@
+const instances: any[] = [];
+jest.mock('ssh2', () => {
+  const { EventEmitter } = require('events');
+  return {
+    Client: jest.fn(() => {
+      const client = new EventEmitter();
+      client.connect = jest.fn();
+      client.end = jest.fn();
+      client.shell = jest.fn(cb => {
+        client.shellCallback = cb;
+      });
+      instances.push(client);
+      return client;
+    }),
+  };
+});
+
+import { SshService } from '../ssh.service';
+import { EventEmitter } from 'events';
+
+class MockStream extends EventEmitter {
+  end = jest.fn();
+  write = jest.fn();
+}
+
+describe('SshService', () => {
+  it('should resolve session on ready', async () => {
+    const service = new SshService();
+    const promise = service.createSession({ host: 'h', username: 'u', password: 'p' });
+    const client = instances[0];
+    const stream = new MockStream();
+    client.emit('ready');
+    client.shellCallback(null, stream);
+    const session = await promise;
+    expect(session.client).toBe(client);
+    expect(session.shell).toBe(stream);
+    expect(client.connect).toHaveBeenCalledWith({ host: 'h', username: 'u', password: 'p' });
+  });
+
+  it('should reject on error', async () => {
+    const service = new SshService();
+    const promise = service.createSession({ host: 'h', username: 'u', password: 'p' });
+    const client = instances[1];
+    const error = new Error('fail');
+    client.emit('error', error);
+    await expect(promise).rejects.toThrow('fail');
+  });
+});

--- a/src/modules/ssh/domain/services/ssh.service.ts
+++ b/src/modules/ssh/domain/services/ssh.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { Client, ClientChannel } from 'ssh2';
+
+export interface SshSession {
+  client: Client;
+  shell: ClientChannel;
+}
+
+@Injectable()
+export class SshService {
+  async createSession(options: {
+    host: string;
+    username: string;
+    password: string;
+  }): Promise<SshSession> {
+    const client = new Client();
+    return new Promise((resolve, reject) => {
+      client
+        .on('ready', () => {
+          client.shell((err, stream) => {
+            if (err) {
+              client.end();
+              return reject(err);
+            }
+            resolve({ client, shell: stream });
+          });
+        })
+        .on('error', err => reject(err))
+        .connect({
+          host: options.host,
+          username: options.username,
+          password: options.password,
+        });
+    });
+  }
+}

--- a/src/modules/ssh/index.ts
+++ b/src/modules/ssh/index.ts
@@ -1,0 +1,4 @@
+export * from './ssh.module';
+export * from './application/gateway/ssh.gateway';
+export * from './application/use-cases/open-ssh-session.use-case';
+export * from './domain/services/ssh.service';

--- a/src/modules/ssh/ssh.module.ts
+++ b/src/modules/ssh/ssh.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SshGateway } from './application/gateway/ssh.gateway';
+import { OpenSshSessionUseCase } from './application/use-cases/open-ssh-session.use-case';
+import { SshService } from './domain/services/ssh.service';
+
+@Module({
+  providers: [SshGateway, OpenSshSessionUseCase, SshService],
+})
+export class SshModule {}


### PR DESCRIPTION
## Summary
- add ssh2 dependency and SshModule
- implement SshService to open SSH sessions
- add OpenSshSessionUseCase
- expose SshGateway handling websocket communication
- import SshModule in AppModule
- cover the new module with unit tests

## Testing
- `pnpm test`
- `pnpm test:cov` *(fails: Jest global coverage threshold not met)*