### PR TITLE
feat/history: audit logging support

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { PresenceModule } from './modules/presence/presence.module';
 import { GuardsModule } from './core/guards.module';
 import { SetupModule } from './modules/setup/setup.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
+import { HistoryModule } from './modules/history/history.module';
 
 @Module({
   controllers: [],
@@ -38,6 +39,7 @@ import { DashboardModule } from './modules/dashboard/dashboard.module';
     RedisModule,
     PresenceModule,
     SetupModule,
+    HistoryModule,
     DashboardModule,
   ],
   providers: [Logger],

--- a/src/modules/dashboard/application/controllers/dashboard.controller.ts
+++ b/src/modules/dashboard/application/controllers/dashboard.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, UseGuards, Query, Optional } from '@nestjs/common';
 import { FullDashboardStatsDto } from '../dto/fullDashboardStats.dto';
 import {
   ApiBearerAuth,
@@ -7,6 +7,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { GetDashboardFullStatsUseCase } from '../use-cases';
+import { GetHistoryStatsUseCase } from '@/modules/history/application/use-cases';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
 
 @ApiTags('Dashboard')
@@ -19,6 +20,7 @@ export class DashboardController {
    */
   constructor(
     private readonly getDashboardFullStats: GetDashboardFullStatsUseCase,
+    @Optional() private readonly getHistoryStats?: GetHistoryStatsUseCase,
   ) {}
 
   @Get('full')
@@ -33,5 +35,16 @@ export class DashboardController {
    */
   async getFullDashboard(): Promise<FullDashboardStatsDto> {
     return this.getDashboardFullStats.execute();
+  }
+
+  @Get('history')
+  @ApiOperation({ summary: 'Get creation stats for an entity' })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  async getHistory(
+    @Query('entity') entity: string,
+    @Query('months') months = '6',
+  ): Promise<Record<string, number>> {
+    return this.getHistoryStats?.execute(entity, Number(months)) ?? {};
   }
 }

--- a/src/modules/history/application/use-cases/get-history-stats.use-case.ts
+++ b/src/modules/history/application/use-cases/get-history-stats.use-case.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+
+@Injectable()
+export class GetHistoryStatsUseCase {
+  constructor(
+    @Inject('HistoryRepositoryInterface')
+    private readonly repo: HistoryRepositoryInterface,
+  ) {}
+
+  async execute(entity: string, months: number): Promise<Record<string, number>> {
+    return this.repo.countCreatedByMonth(entity, months);
+  }
+}

--- a/src/modules/history/application/use-cases/index.ts
+++ b/src/modules/history/application/use-cases/index.ts
@@ -1,0 +1,2 @@
+export * from './log-history.use-case';
+export * from './get-history-stats.use-case';

--- a/src/modules/history/application/use-cases/log-history.use-case.ts
+++ b/src/modules/history/application/use-cases/log-history.use-case.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+import { HistoryEvent } from '../../domain/entities/history-event.entity';
+
+@Injectable()
+export class LogHistoryUseCase {
+  constructor(
+    @Inject('HistoryRepositoryInterface')
+    private readonly repo: HistoryRepositoryInterface,
+  ) {}
+
+  async execute(entity: string, entityId: string, action: string): Promise<void> {
+    const event = new HistoryEvent();
+    event.entity = entity;
+    event.entityId = entityId;
+    event.action = action;
+    await this.repo.save(event);
+  }
+}

--- a/src/modules/history/domain/entities/history-event.entity.ts
+++ b/src/modules/history/domain/entities/history-event.entity.ts
@@ -1,0 +1,25 @@
+import { BaseEntity, CreateDateColumn, Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('history_event')
+export class HistoryEvent extends BaseEntity {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ApiProperty({ description: 'Entity type, e.g. user, server' })
+  @Column()
+  entity!: string;
+
+  @ApiProperty({ description: 'Identifier of the entity instance' })
+  @Column()
+  entityId!: string;
+
+  @ApiProperty({ description: 'Action performed like CREATE, UPDATE, DELETE' })
+  @Column()
+  action!: string;
+
+  @ApiProperty()
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/src/modules/history/domain/interfaces/history.repository.interface.ts
+++ b/src/modules/history/domain/interfaces/history.repository.interface.ts
@@ -1,0 +1,7 @@
+import { GenericRepositoryInterface } from '@/core/types/generic-repository.interface';
+import { HistoryEvent } from '../entities/history-event.entity';
+
+export interface HistoryRepositoryInterface
+  extends GenericRepositoryInterface<HistoryEvent> {
+  countCreatedByMonth(entity: string, months: number): Promise<Record<string, number>>;
+}

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HistoryEvent } from './domain/entities/history-event.entity';
+import { HistoryEventTypeormRepository } from './infrastructure/repositories/history-event.typeorm.repository';
+import { GetHistoryStatsUseCase, LogHistoryUseCase } from './application/use-cases';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([HistoryEvent])],
+  providers: [
+    LogHistoryUseCase,
+    GetHistoryStatsUseCase,
+    {
+      provide: 'HistoryRepositoryInterface',
+      useClass: HistoryEventTypeormRepository,
+    },
+  ],
+  exports: [LogHistoryUseCase, GetHistoryStatsUseCase, 'HistoryRepositoryInterface'],
+})
+export class HistoryModule {}

--- a/src/modules/history/infrastructure/repositories/history-event.typeorm.repository.ts
+++ b/src/modules/history/infrastructure/repositories/history-event.typeorm.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { HistoryEvent } from '../../domain/entities/history-event.entity';
+import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+
+@Injectable()
+export class HistoryEventTypeormRepository
+  extends Repository<HistoryEvent>
+  implements HistoryRepositoryInterface
+{
+  constructor(private readonly dataSource: DataSource) {
+    super(HistoryEvent, dataSource.createEntityManager());
+  }
+
+  async count(): Promise<number> {
+    return this.repository.count();
+  }
+
+  private get repository(): Repository<HistoryEvent> {
+    return this.dataSource.getRepository(HistoryEvent);
+  }
+
+  async save(entity: HistoryEvent): Promise<HistoryEvent> {
+    return this.repository.save(entity);
+  }
+
+  async findAll(): Promise<HistoryEvent[]> {
+    return this.repository.find();
+  }
+
+  async findOneByField<K extends keyof HistoryEvent>({
+    field,
+    value,
+  }: {
+    field: K;
+    value: HistoryEvent[K];
+  }): Promise<HistoryEvent | null> {
+    return this.repository.findOne({ where: { [field]: value } as any });
+  }
+
+  async countCreatedByMonth(
+    entity: string,
+    months: number,
+  ): Promise<Record<string, number>> {
+    const qb = this.repository
+      .createQueryBuilder('history')
+      .select("to_char(history.createdAt, 'YYYY-MM')", 'month')
+      .addSelect('COUNT(*)', 'count')
+      .where('history.entity = :entity', { entity })
+      .andWhere('history.action = :action', { action: 'CREATE' })
+      .andWhere(`history.createdAt >= NOW() - INTERVAL '${months} months'`)
+      .groupBy('month')
+      .orderBy('month', 'ASC');
+
+    const results = await qb.getRawMany<{ month: string; count: string }>();
+    return results.reduce<Record<string, number>>((acc, curr) => {
+      acc[curr.month] = Number(curr.count);
+      return acc;
+    }, {});
+  }
+}

--- a/src/modules/rooms/application/use-cases/create-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/create-room.use-case.ts
@@ -1,16 +1,19 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { RoomRepositoryInterface } from '../../domain/interfaces/room.repository.interface';
 import { RoomResponseDto, RoomCreationDto } from '../dto';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class CreateRoomUseCase {
   constructor(
     @Inject('RoomRepositoryInterface')
     private readonly roomRepository: RoomRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(dto: RoomCreationDto): Promise<RoomResponseDto> {
     const room = await this.roomRepository.createRoom(dto.name);
+    await this.logHistory?.execute('room', room.id, 'CREATE');
     return RoomResponseDto.from(room);
   }
 }

--- a/src/modules/rooms/application/use-cases/delete-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/delete-room.use-case.ts
@@ -1,14 +1,17 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { RoomRepositoryInterface } from '../../domain/interfaces/room.repository.interface';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class DeleteRoomUseCase {
   constructor(
     @Inject('RoomRepositoryInterface')
     private readonly roomRepository: RoomRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
     await this.roomRepository.deleteRoom(id);
+    await this.logHistory?.execute('room', id, 'DELETE');
   }
 }

--- a/src/modules/rooms/application/use-cases/update-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/update-room.use-case.ts
@@ -1,16 +1,19 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { RoomRepositoryInterface } from '../../domain/interfaces/room.repository.interface';
 import { RoomResponseDto, RoomCreationDto } from '../dto';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class UpdateRoomUseCase {
   constructor(
     @Inject('RoomRepositoryInterface')
     private readonly roomRepository: RoomRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string, dto: RoomCreationDto): Promise<RoomResponseDto> {
     const room = await this.roomRepository.updateRoom(id, dto.name);
+    await this.logHistory?.execute('room', room.id, 'UPDATE');
     return RoomResponseDto.from(room);
   }
 }

--- a/src/modules/rooms/room.module.ts
+++ b/src/modules/rooms/room.module.ts
@@ -5,10 +5,11 @@ import { Room } from './domain/entities/room.entity';
 import { RoomTypeormRepository } from './infrastructure/repositories/room.typeorm.repository';
 import { RoomUseCases } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
+import { HistoryModule } from '../history/history.module';
 
 @Module({
   controllers: [RoomController],
-  imports: [TypeOrmModule.forFeature([Room]), forwardRef(() => SetupModule)],
+  imports: [TypeOrmModule.forFeature([Room]), forwardRef(() => SetupModule), HistoryModule],
   providers: [
     ...RoomUseCases,
     {

--- a/src/modules/servers/application/use-cases/create-server.use-case.ts
+++ b/src/modules/servers/application/use-cases/create-server.use-case.ts
@@ -10,6 +10,7 @@ import { GroupServerRepositoryInterface } from '@/modules/groups/domain/interfac
 import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
 import { PermissionBit } from '@/modules/permissions/domain/value-objects/permission-bit.enum';
 import { PermissionServerRepositoryInterface } from '@/modules/permissions/infrastructure/interfaces/permission.server.repository.interface';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class CreateServerUseCase {
@@ -26,6 +27,7 @@ export class CreateServerUseCase {
     private readonly userRepository: UserRepositoryInterface,
     @Inject('PermissionServerRepositoryInterface')
     private readonly permissionRepository: PermissionServerRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(
@@ -50,6 +52,7 @@ export class CreateServerUseCase {
 
     const entity = this.serverDomain.createServerEntityFromDto(dto, ilo.id);
     const server = await this.serverRepository.save(entity);
+    await this.logHistory?.execute('server', server.id, 'CREATE');
 
     const user = await this.userRepository.findOneByField({
       field: 'id',

--- a/src/modules/servers/application/use-cases/delete-server.use-case.ts
+++ b/src/modules/servers/application/use-cases/delete-server.use-case.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ServerRepositoryInterface } from '@/modules/servers/domain/interfaces/server.repository.interface';
 
 import { DeleteIloUseCase } from '@/modules/ilos/application/use-cases';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class DeleteServerUseCase {
@@ -9,10 +10,12 @@ export class DeleteServerUseCase {
     @Inject('ServerRepositoryInterface')
     private readonly serverRepository: ServerRepositoryInterface,
     private readonly deleteIloUsecase: DeleteIloUseCase,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
     await this.serverRepository.deleteServer(id);
     await this.deleteIloUsecase.execute(id);
+    await this.logHistory?.execute('server', id, 'DELETE');
   }
 }

--- a/src/modules/servers/server.module.ts
+++ b/src/modules/servers/server.module.ts
@@ -10,6 +10,7 @@ import { PermissionModule } from '../permissions/permission.module';
 import { UserModule } from '../users/user.module';
 import { RoomModule } from '../rooms/room.module';
 import { GroupModule } from '../groups/group.module';
+import { HistoryModule } from '../history/history.module';
 
 @Module({
   controllers: [ServerController],
@@ -22,6 +23,7 @@ import { GroupModule } from '../groups/group.module';
     forwardRef(() => RoomModule),
     GroupModule,
     PermissionModule,
+    HistoryModule,
   ],
   providers: [
     ...ServerUseCases,

--- a/src/modules/ups/application/use-cases/create-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/create-ups.use-case.ts
@@ -3,6 +3,7 @@ import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.i
 import { UpsCreationDto } from '../../application/dto/ups.creation.dto';
 import { UpsResponseDto } from '../../application/dto/ups.response.dto';
 import { UpsDomainService } from '../../domain/services/ups.domain.service';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class CreateUpsUseCase {
@@ -10,6 +11,7 @@ export class CreateUpsUseCase {
     @Inject('UpsRepositoryInterface')
     private readonly upsRepository: UpsRepositoryInterface,
     private readonly upsDomainService: UpsDomainService,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(dto: UpsCreationDto): Promise<UpsResponseDto> {
@@ -18,7 +20,7 @@ export class CreateUpsUseCase {
     const saved = await this.upsRepository.save(entity);
 
     const ups = Array.isArray(saved) ? saved[0] : saved;
-
+    await this.logHistory?.execute('ups', ups.id, 'CREATE');
     return new UpsResponseDto(ups);
   }
 }

--- a/src/modules/ups/application/use-cases/delete-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/delete-ups.use-case.ts
@@ -1,15 +1,18 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.interface';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class DeleteUpsUseCase {
   constructor(
     @Inject('UpsRepositoryInterface')
     private readonly upsRepository: UpsRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
     await this.upsRepository.findUpsById(id);
     await this.upsRepository.deleteUps(id);
+    await this.logHistory?.execute('ups', id, 'DELETE');
   }
 }

--- a/src/modules/ups/application/use-cases/update-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/update-ups.use-case.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.interface';
 import { UpsUpdateDto } from '../../application/dto/ups.update.dto';
 import { UpsResponseDto } from '../../application/dto/ups.response.dto';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class UpdateUpsUseCase {
@@ -10,6 +11,7 @@ export class UpdateUpsUseCase {
     @Inject('UpsRepositoryInterface')
     private readonly upsRepository: UpsRepositoryInterface,
     private readonly upsDomainService: UpsDomainService,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string, dto: UpsUpdateDto): Promise<UpsResponseDto> {
@@ -18,7 +20,7 @@ export class UpdateUpsUseCase {
     ups = await this.upsDomainService.createUpsEntityFromUpdateDto(ups, dto);
     const saved = await this.upsRepository.save(ups);
     ups = Array.isArray(saved) ? saved[0] : saved;
-
+    await this.logHistory?.execute('ups', ups.id, 'UPDATE');
     return new UpsResponseDto(ups);
   }
 }

--- a/src/modules/ups/ups.module.ts
+++ b/src/modules/ups/ups.module.ts
@@ -5,11 +5,12 @@ import { Ups } from './domain/entities/ups.entity';
 import { UpsTypeormRepository } from './infrastructure/repositories/ups.typeorm.repository';
 import { UpsUseCases } from './application/use-cases';
 import { UpsDomainService } from './domain/services/ups.domain.service';
+import { HistoryModule } from '../history/history.module';
 
 @Module({
   controllers: [UpsController],
   exports: [...UpsUseCases, 'UpsRepositoryInterface'],
-  imports: [TypeOrmModule.forFeature([Ups])],
+  imports: [TypeOrmModule.forFeature([Ups]), HistoryModule],
   providers: [
     ...UpsUseCases,
     UpsDomainService,

--- a/src/modules/users/application/use-cases/delete-user.use-case.ts
+++ b/src/modules/users/application/use-cases/delete-user.use-case.ts
@@ -1,4 +1,5 @@
 import { Inject } from '@nestjs/common';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 import { UserRepositoryInterface } from '../../domain/interfaces/user.repository.interface';
 
@@ -6,6 +7,7 @@ export class DeleteUserUseCase {
   constructor(
     @Inject('UserRepositoryInterface')
     private readonly repo: UserRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
@@ -14,5 +16,6 @@ export class DeleteUserUseCase {
       value: id,
     });
     await this.repo.deleteUser(id);
+    await this.logHistory?.execute('user', id, 'DELETE');
   }
 }

--- a/src/modules/users/application/use-cases/register-user.use-case.ts
+++ b/src/modules/users/application/use-cases/register-user.use-case.ts
@@ -5,6 +5,7 @@ import { EnsureDefaultRoleUseCase } from '@/modules/roles/application/use-cases'
 import { RegisterDto } from '@/modules/auth/application/dto/register.dto';
 import { User } from '../../domain/entities/user.entity';
 import { UserConflictException } from '../../domain/exceptions/user.exception';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 export class RegisterUserUseCase {
   constructor(
@@ -12,6 +13,7 @@ export class RegisterUserUseCase {
     private readonly repo: UserRepositoryInterface,
     private readonly domain: UserDomainService,
     private readonly ensureDefaultRoleUseCase: EnsureDefaultRoleUseCase,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(dto: RegisterDto): Promise<User> {
@@ -39,6 +41,8 @@ export class RegisterUserUseCase {
       dto.firstName,
       dto.lastName,
     );
-    return await this.repo.save(user);
+    const saved = await this.repo.save(user);
+    await this.logHistory?.execute('user', saved.id, 'CREATE');
+    return saved;
   }
 }

--- a/src/modules/users/application/use-cases/update-user.use-case.ts
+++ b/src/modules/users/application/use-cases/update-user.use-case.ts
@@ -3,6 +3,7 @@ import { UserRepositoryInterface } from '../../domain/interfaces/user.repository
 import { UserResponseDto } from '../dto/user.response.dto';
 import { UserUpdateDto } from '../dto/user.update.dto';
 import { UserDomainService } from '../../domain/services/user.domain.service';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class UpdateUserUseCase {
@@ -10,6 +11,7 @@ export class UpdateUserUseCase {
     @Inject('UserRepositoryInterface')
     private readonly repo: UserRepositoryInterface,
     private readonly userDomainService: UserDomainService,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string, dto: UserUpdateDto): Promise<UserResponseDto> {
@@ -22,6 +24,7 @@ export class UpdateUserUseCase {
     await this.userDomainService.ensureUniqueUsername(dto.username, id);
     user = await this.userDomainService.updateUserEntity(user, dto);
     user = await this.repo.save(user);
+    await this.logHistory?.execute('user', user.id, 'UPDATE');
     return new UserResponseDto(user);
   }
 }

--- a/src/modules/users/user.module.ts
+++ b/src/modules/users/user.module.ts
@@ -7,6 +7,7 @@ import { UserDomainService } from './domain/services/user.domain.service';
 import { RoleModule } from '../roles/role.module';
 import { UserUseCase } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
+import { HistoryModule } from '../history/history.module';
 
 @Module({
   controllers: [UserController],
@@ -15,6 +16,7 @@ import { SetupModule } from '../setup/setup.module';
     TypeOrmModule.forFeature([User]),
     forwardRef(() => RoleModule),
     forwardRef(() => SetupModule),
+    HistoryModule,
   ],
   providers: [
     ...UserUseCase,


### PR DESCRIPTION
## Summary
- add History module with `HistoryEvent` entity to store creation events
- log create/update/delete operations for users, servers, rooms and UPS
- expose optional dashboard endpoint to query creation stats
- wire History module into main app

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_685dbb122de0832d908c949fd302cda0