### PR TITLE
feat/auth: centralize token generation

### DIFF
--- a/src/modules/auth/application/services/__tests__/token.service.spec.ts
+++ b/src/modules/auth/application/services/__tests__/token.service.spec.ts
@@ -1,0 +1,50 @@
+import { TokenService } from '../token.service';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+describe('TokenService', () => {
+  let service: TokenService;
+  let jwtService: jest.Mocked<JwtService>;
+  let configService: jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    jwtService = { sign: jest.fn() } as any;
+    configService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        switch (key) {
+          case 'JWT_ACCESS_TOKEN_EXPIRATION':
+            return '15m';
+          case 'JWT_REFRESH_TOKEN_EXPIRATION':
+            return '7d';
+          case 'JWT_2FA_TOKEN_EXPIRATION':
+            return '5m';
+          default:
+            return undefined;
+        }
+      }),
+    } as any;
+
+    service = new TokenService(jwtService, configService);
+  });
+
+  it('should generate access and refresh tokens', () => {
+    jwtService.sign
+      .mockReturnValueOnce('access.token')
+      .mockReturnValueOnce('refresh.token');
+
+    const result = service.generateTokens({ userId: '1' });
+
+    expect(jwtService.sign).toHaveBeenNthCalledWith(1, { userId: '1' }, { expiresIn: '15m' });
+    expect(jwtService.sign).toHaveBeenNthCalledWith(2, { userId: '1' }, { expiresIn: '7d' });
+    expect(result).toEqual({ accessToken: 'access.token', refreshToken: 'refresh.token' });
+  });
+
+  it('should generate a 2FA token', () => {
+    jwtService.sign.mockReturnValue('2fa.token');
+
+    const result = service.generate2FAToken({ userId: '1' });
+
+    expect(jwtService.sign).toHaveBeenCalledWith({ userId: '1' }, { expiresIn: '5m' });
+    expect(result).toBe('2fa.token');
+  });
+});

--- a/src/modules/auth/application/services/token.service.ts
+++ b/src/modules/auth/application/services/token.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class TokenService {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  generateTokens(payload: object) {
+    const accessToken = this.jwtService.sign(payload, {
+      expiresIn: this.configService.get<string>('JWT_ACCESS_TOKEN_EXPIRATION'),
+    });
+    const refreshToken = this.jwtService.sign(payload, {
+      expiresIn: this.configService.get<string>('JWT_REFRESH_TOKEN_EXPIRATION'),
+    });
+    return { accessToken, refreshToken };
+  }
+
+  generate2FAToken(payload: object) {
+    return this.jwtService.sign(payload, {
+      expiresIn: this.configService.get<string>('JWT_2FA_TOKEN_EXPIRATION'),
+    });
+  }
+}

--- a/src/modules/auth/application/use-cases/__tests__/register.use-case.spec.ts
+++ b/src/modules/auth/application/use-cases/__tests__/register.use-case.spec.ts
@@ -1,6 +1,5 @@
 import { RegisterUseCase } from '../register.use-case';
-import { JwtService } from '@nestjs/jwt';
-import { ConfigService } from '@nestjs/config';
+import { TokenService } from '../../services/token.service';
 import { RegisterDto } from '../../dto/register.dto';
 import { createMockUser } from '@/modules/auth/__mocks__/user.mock';
 import { RegisterUserUseCase } from '@/modules/users/application/use-cases';
@@ -8,8 +7,7 @@ import { RegisterUserUseCase } from '@/modules/users/application/use-cases';
 describe('RegisterUseCase', () => {
   let useCase: RegisterUseCase;
   let registerUserUseCase: jest.Mocked<RegisterUserUseCase>;
-  let jwtService: jest.Mocked<JwtService>;
-  let configService: jest.Mocked<ConfigService>;
+  let tokenService: jest.Mocked<TokenService>;
 
   const mockDto: RegisterDto = {
     firstName: 'John',
@@ -24,56 +22,29 @@ describe('RegisterUseCase', () => {
       execute: jest.fn(),
     } as any;
 
-    jwtService = {
-      sign: jest.fn(),
+    tokenService = {
+      generateTokens: jest.fn(),
     } as any;
 
-    configService = {
-      get: jest.fn().mockImplementation((key: string) => {
-        switch (key) {
-          case 'JWT_ACCESS_TOKEN_EXPIRATION':
-            return '15m';
-          case 'JWT_REFRESH_TOKEN_EXPIRATION':
-            return '7d';
-          default:
-            return undefined;
-        }
-      }),
-    } as any;
-
-    useCase = new RegisterUseCase(
-      registerUserUseCase,
-      jwtService,
-      configService,
-    );
+    useCase = new RegisterUseCase(registerUserUseCase, tokenService);
   });
 
   it('should register a new user and return access and refresh tokens', async () => {
     const fakeUser = createMockUser();
     registerUserUseCase.execute.mockResolvedValue(fakeUser);
-    jwtService.sign
-      .mockReturnValueOnce('access.jwt.token')
-      .mockReturnValueOnce('refresh.jwt.token');
+    tokenService.generateTokens.mockReturnValue({
+      accessToken: 'access.jwt.token',
+      refreshToken: 'refresh.jwt.token',
+    });
 
     const result = await useCase.execute(mockDto);
 
     expect(registerUserUseCase.execute).toHaveBeenCalledWith(mockDto);
-    expect(jwtService.sign).toHaveBeenCalledWith(
-      {
-        userId: fakeUser.id,
-        email: fakeUser.email,
-        isTwoFactorEnabled: fakeUser.isTwoFactorEnabled,
-      },
-      { expiresIn: '15m' },
-    );
-    expect(jwtService.sign).toHaveBeenCalledWith(
-      {
-        userId: fakeUser.id,
-        email: fakeUser.email,
-        isTwoFactorEnabled: fakeUser.isTwoFactorEnabled,
-      },
-      { expiresIn: '7d' },
-    );
+    expect(tokenService.generateTokens).toHaveBeenCalledWith({
+      userId: fakeUser.id,
+      email: fakeUser.email,
+      isTwoFactorEnabled: fakeUser.isTwoFactorEnabled,
+    });
     expect(result).toEqual({
       accessToken: 'access.jwt.token',
       refreshToken: 'refresh.jwt.token',

--- a/src/modules/auth/application/use-cases/register.use-case.ts
+++ b/src/modules/auth/application/use-cases/register.use-case.ts
@@ -1,43 +1,21 @@
 import { Injectable } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
-import { ConfigService } from '@nestjs/config';
 import { RegisterDto } from '../dto/register.dto';
 import { RegisterUserUseCase } from '@/modules/users/application/use-cases';
+import { TokenService } from '../services/token.service';
 
 @Injectable()
 export class RegisterUseCase {
   constructor(
     private readonly registerUserUseCase: RegisterUserUseCase,
-    private readonly jwtService: JwtService,
-    private readonly configService: ConfigService,
+    private readonly tokenService: TokenService,
   ) {}
 
   async execute(dto: RegisterDto) {
     const user = await this.registerUserUseCase.execute(dto);
-    const accessToken = this.jwtService.sign(
-      {
-        userId: user.id,
-        email: user.email,
-        isTwoFactorEnabled: user.isTwoFactorEnabled,
-      },
-      {
-        expiresIn: this.configService.get<string>(
-          'JWT_ACCESS_TOKEN_EXPIRATION',
-        ),
-      },
-    );
-    const refreshToken = this.jwtService.sign(
-      {
-        userId: user.id,
-        email: user.email,
-        isTwoFactorEnabled: user.isTwoFactorEnabled,
-      },
-      {
-        expiresIn: this.configService.get<string>(
-          'JWT_REFRESH_TOKEN_EXPIRATION',
-        ),
-      },
-    );
-    return { accessToken, refreshToken };
+    return this.tokenService.generateTokens({
+      userId: user.id,
+      email: user.email,
+      isTwoFactorEnabled: user.isTwoFactorEnabled,
+    });
   }
 }

--- a/src/modules/auth/application/use-cases/renew-token.use-case.ts
+++ b/src/modules/auth/application/use-cases/renew-token.use-case.ts
@@ -1,13 +1,13 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { ConfigService } from '@nestjs/config';
 import { JwtPayload } from '@/core/types/jwt-payload.interface';
+import { TokenService } from '../services/token.service';
 
 @Injectable()
 export class RenewTokenUseCase {
   constructor(
     private readonly jwtService: JwtService,
-    private readonly configService: ConfigService,
+    private readonly tokenService: TokenService,
   ) {}
 
   execute(refreshToken: string) {
@@ -16,35 +16,14 @@ export class RenewTokenUseCase {
         JwtPayload & { isTwoFactorEnabled?: boolean; role?: any }
       >(refreshToken);
 
-      const accessToken = this.jwtService.sign(
-        {
-          userId: payload.userId,
-          email: payload.email,
-          isTwoFactorEnabled: payload.isTwoFactorEnabled,
-          role: payload.role,
-        },
-        {
-          expiresIn: this.configService.get<string>(
-            'JWT_ACCESS_TOKEN_EXPIRATION',
-          ),
-        },
-      );
+      const tokens = this.tokenService.generateTokens({
+        userId: payload.userId,
+        email: payload.email,
+        isTwoFactorEnabled: payload.isTwoFactorEnabled,
+        role: payload.role,
+      });
 
-      const newRefreshToken = this.jwtService.sign(
-        {
-          userId: payload.userId,
-          email: payload.email,
-          isTwoFactorEnabled: payload.isTwoFactorEnabled,
-          role: payload.role,
-        },
-        {
-          expiresIn: this.configService.get<string>(
-            'JWT_REFRESH_TOKEN_EXPIRATION',
-          ),
-        },
-      );
-
-      return { accessToken, refreshToken: newRefreshToken };
+      return tokens;
     } catch {
       throw new UnauthorizedException('Invalid or expired refresh token');
     }

--- a/src/modules/auth/application/use-cases/verify-2fa-recovery.use-case.ts
+++ b/src/modules/auth/application/use-cases/verify-2fa-recovery.use-case.ts
@@ -1,5 +1,6 @@
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { TokenService } from '../services/token.service';
 
 import { JwtPayload } from '@/core/types/jwt-payload.interface';
 
@@ -15,6 +16,7 @@ export class Verify2FARecoveryUseCase {
     private readonly getUserByEmailUseCase: GetUserByEmailUseCase,
     private readonly updateUserFieldsUseCase: UpdateUserFieldsUseCase,
     private readonly jwtService: JwtService,
+    private readonly tokenService: TokenService,
   ) {}
 
   async execute(
@@ -56,7 +58,7 @@ export class Verify2FARecoveryUseCase {
       recoveryCodes: updatedCodes,
     });
 
-    const accessToken = this.jwtService.sign({
+    const accessToken = this.tokenService.generate2FAToken({
       userId: user.id,
       email: user.email,
       isTwoFactorAuthenticated: true,

--- a/src/modules/auth/application/use-cases/verify-2fa.use-case.ts
+++ b/src/modules/auth/application/use-cases/verify-2fa.use-case.ts
@@ -2,6 +2,7 @@ import { RecoveryCodeService } from './../../domain/services/recovery-code.domai
 import { Injectable } from '@nestjs/common';
 import * as speakeasy from 'speakeasy';
 import { JwtService } from '@nestjs/jwt';
+import { TokenService } from '../services/token.service';
 
 import { JwtPayload } from '@/core/types/jwt-payload.interface';
 import { TwoFADto, TwoFAResponseDto } from '../dto/twofa.dto';
@@ -20,6 +21,7 @@ export class Verify2FAUseCase {
     private readonly updateUserFieldsUseCase: UpdateUserFieldsUseCase,
     private readonly recoveryCodeService: RecoveryCodeService,
     private readonly jwtService: JwtService,
+    private readonly tokenService: TokenService,
   ) {}
 
   async execute(
@@ -53,7 +55,7 @@ export class Verify2FAUseCase {
         '2FA activated successfully. Store your recovery codes securely.';
     }
 
-    const accessToken = this.jwtService.sign({
+    const accessToken = this.tokenService.generate2FAToken({
       userId: user.id,
       email: user.email,
       isTwoFactorAuthenticated: true,

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { PassportModule } from '@nestjs/passport';
 import { TwoFAController } from './application/controllers/twofa.controller';
 import { RecoveryCodeService } from './domain/services/recovery-code.domain.service';
 import { AuthUseCases } from './application/use-cases';
+import { TokenService } from './application/services/token.service';
 
 @Module({
   imports: [
@@ -26,7 +27,7 @@ import { AuthUseCases } from './application/use-cases';
     }),
   ],
   controllers: [AuthController, TwoFAController],
-  providers: [JwtStrategy, RecoveryCodeService, ...AuthUseCases],
+  providers: [JwtStrategy, RecoveryCodeService, TokenService, ...AuthUseCases],
   exports: [JwtModule],
 })
 export class AuthModule {}


### PR DESCRIPTION
## Summary
- create TokenService to handle JWT token creation
- use TokenService in register, login, and renew token flows
- update 2FA verification to reuse TokenService
- cover TokenService and refactored use cases in tests

## Testing
- `pnpm test`