### PR TITLE
feat/history: audit logging support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infra-control",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "author": "",
   "private": true,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { PresenceModule } from './modules/presence/presence.module';
 import { GuardsModule } from './core/guards.module';
 import { SetupModule } from './modules/setup/setup.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
+import { HistoryModule } from './modules/history/history.module';
 
 @Module({
   controllers: [],
@@ -38,6 +39,7 @@ import { DashboardModule } from './modules/dashboard/dashboard.module';
     RedisModule,
     PresenceModule,
     SetupModule,
+    HistoryModule,
     DashboardModule,
   ],
   providers: [Logger],

--- a/src/core/decorators/role.decorator.ts
+++ b/src/core/decorators/role.decorator.ts
@@ -5,6 +5,7 @@ export const ROLE_KEY = 'role';
 export interface RoleRequirement {
   canCreateServer?: boolean;
   canCreateVm?: boolean;
+  isAdmin?: boolean;
 }
 
 export const RequireRole = (requirement: RoleRequirement) =>

--- a/src/core/filters/__tests__/permission.filter.spec.ts
+++ b/src/core/filters/__tests__/permission.filter.spec.ts
@@ -22,7 +22,9 @@ describe('PermissionFilters', () => {
     const filter = new PermissionCreationExceptionFilter();
     const { host, response, json } = createHost();
     filter.catch(new PermissionCreationException('oops'), host);
-    expect(response.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(response.status).toHaveBeenCalledWith(
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
     expect(json).toHaveBeenCalledWith({ statusCode: 500, message: 'oops' });
   });
 
@@ -30,7 +32,9 @@ describe('PermissionFilters', () => {
     const filter = new PermissionDeletionExceptionFilter();
     const { host, response, json } = createHost();
     filter.catch(new PermissionDeletionException('del'), host);
-    expect(response.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(response.status).toHaveBeenCalledWith(
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
     expect(json).toHaveBeenCalledWith({ statusCode: 500, message: 'del' });
   });
 

--- a/src/core/filters/simple-message.filter.ts
+++ b/src/core/filters/simple-message.filter.ts
@@ -1,4 +1,10 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus, Type } from '@nestjs/common';
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+  Type,
+} from '@nestjs/common';
 
 export function createSimpleMessageFilter(
   exceptionType: Type<Error>,

--- a/src/core/guards.module.ts
+++ b/src/core/guards.module.ts
@@ -1,4 +1,4 @@
-import { Module, Global } from '@nestjs/common';
+import { Module, Global, forwardRef } from '@nestjs/common';
 
 import { PermissionGuard } from './guards/permission.guard';
 import { RoleGuard } from './guards/role.guard';
@@ -12,7 +12,7 @@ import { ResourcePermissionGuard } from './guards/ressource-permission.guard';
 
 @Global()
 @Module({
-  imports: [PermissionModule, UserModule],
+  imports: [PermissionModule, forwardRef(() => UserModule)],
   providers: [
     PermissionGuard,
     RoleGuard,

--- a/src/modules/audit/audit.module.ts
+++ b/src/modules/audit/audit.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HistoryEvent } from '../history/domain/entities/history-event.entity';
+import { HistoryEventTypeormRepository } from '../history/infrastructure/repositories/history-event.typeorm.repository';
+import { LogHistoryUseCase } from '../history/application/use-cases/log-history.use-case';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([HistoryEvent])],
+  providers: [
+    LogHistoryUseCase,
+    {
+      provide: 'HistoryRepositoryInterface',
+      useClass: HistoryEventTypeormRepository,
+    },
+  ],
+  exports: [LogHistoryUseCase, 'HistoryRepositoryInterface'],
+})
+export class AuditModule {}

--- a/src/modules/auth/application/services/__tests__/token.service.spec.ts
+++ b/src/modules/auth/application/services/__tests__/token.service.spec.ts
@@ -34,9 +34,20 @@ describe('TokenService', () => {
 
     const result = service.generateTokens({ userId: '1' });
 
-    expect(jwtService.sign).toHaveBeenNthCalledWith(1, { userId: '1' }, { expiresIn: '15m' });
-    expect(jwtService.sign).toHaveBeenNthCalledWith(2, { userId: '1' }, { expiresIn: '7d' });
-    expect(result).toEqual({ accessToken: 'access.token', refreshToken: 'refresh.token' });
+    expect(jwtService.sign).toHaveBeenNthCalledWith(
+      1,
+      { userId: '1' },
+      { expiresIn: '15m' },
+    );
+    expect(jwtService.sign).toHaveBeenNthCalledWith(
+      2,
+      { userId: '1' },
+      { expiresIn: '7d' },
+    );
+    expect(result).toEqual({
+      accessToken: 'access.token',
+      refreshToken: 'refresh.token',
+    });
   });
 
   it('should generate a 2FA token', () => {
@@ -44,7 +55,10 @@ describe('TokenService', () => {
 
     const result = service.generate2FAToken({ userId: '1' });
 
-    expect(jwtService.sign).toHaveBeenCalledWith({ userId: '1' }, { expiresIn: '5m' });
+    expect(jwtService.sign).toHaveBeenCalledWith(
+      { userId: '1' },
+      { expiresIn: '5m' },
+    );
     expect(result).toBe('2fa.token');
   });
 });

--- a/src/modules/dashboard/application/controllers/__tests__/dashboard.controller.spec.ts
+++ b/src/modules/dashboard/application/controllers/__tests__/dashboard.controller.spec.ts
@@ -1,18 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DashboardController } from '../dashboard.controller';
 import { GetDashboardFullStatsUseCase } from '../../use-cases';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
+import { RoleGuard } from '@/core/guards/role.guard';
 
 describe('DashboardController', () => {
   let controller: DashboardController;
   const getStats = { execute: jest.fn() } as any;
 
   beforeEach(async () => {
+    const mockJwtGuard = { canActivate: jest.fn().mockReturnValue(true) };
+    const mockRoleGuard = { canActivate: jest.fn().mockReturnValue(true) };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DashboardController],
       providers: [
         { provide: GetDashboardFullStatsUseCase, useValue: getStats },
       ],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtGuard)
+      .overrideGuard(RoleGuard)
+      .useValue(mockRoleGuard)
+      .compile();
 
     controller = module.get(DashboardController);
   });

--- a/src/modules/dashboard/application/controllers/dashboard.controller.ts
+++ b/src/modules/dashboard/application/controllers/dashboard.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, UseGuards, Query, Optional } from '@nestjs/common';
 import { FullDashboardStatsDto } from '../dto/fullDashboardStats.dto';
 import {
   ApiBearerAuth,
@@ -7,6 +7,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { GetDashboardFullStatsUseCase } from '../use-cases';
+import { GetHistoryStatsUseCase } from '@/modules/history/application/use-cases';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
 
 @ApiTags('Dashboard')
@@ -19,6 +20,7 @@ export class DashboardController {
    */
   constructor(
     private readonly getDashboardFullStats: GetDashboardFullStatsUseCase,
+    @Optional() private readonly getHistoryStats?: GetHistoryStatsUseCase,
   ) {}
 
   @Get('full')
@@ -33,5 +35,16 @@ export class DashboardController {
    */
   async getFullDashboard(): Promise<FullDashboardStatsDto> {
     return this.getDashboardFullStats.execute();
+  }
+
+  @Get('history')
+  @ApiOperation({ summary: 'Get creation stats for an entity' })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  async getHistory(
+    @Query('entity') entity: string,
+    @Query('months') months = '6',
+  ): Promise<Record<string, number>> {
+    return this.getHistoryStats?.execute(entity, Number(months)) ?? {};
   }
 }

--- a/src/modules/dashboard/application/controllers/dashboard.controller.ts
+++ b/src/modules/dashboard/application/controllers/dashboard.controller.ts
@@ -9,6 +9,8 @@ import {
 import { GetDashboardFullStatsUseCase } from '../use-cases';
 import { GetHistoryStatsUseCase } from '@/modules/history/application/use-cases';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
+import { RoleGuard } from '@/core/guards';
+import { RequireRole } from '@/core/decorators/role.decorator';
 
 @ApiTags('Dashboard')
 @Controller('dashboard')
@@ -39,8 +41,17 @@ export class DashboardController {
 
   @Get('history')
   @ApiOperation({ summary: 'Get creation stats for an entity' })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
   @ApiBearerAuth()
+  @RequireRole({ isAdmin: true })
+  /**
+   * Retrieve creation statistics for a specific entity over the last N months.
+   * @param entity - The entity type to retrieve statistics for (e.g., 'server', 'vm').
+   * @param months - The number of months to look back for statistics (default is 6).
+   * @returns A record mapping entity creation dates to counts.
+   * @throws BadRequestException if the entity type is not recognized.
+   * @throws NotFoundException if no statistics are available for the specified entity.
+   */
   async getHistory(
     @Query('entity') entity: string,
     @Query('months') months = '6',

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -10,6 +10,7 @@ import { VmModule } from '../vms/vm.module';
 import { UserModule } from '../users/user.module';
 import { RoomModule } from '../rooms/room.module';
 import { UpsModule } from '../ups/ups.module';
+import { RoleModule } from '../roles/role.module';
 
 @Module({
   controllers: [DashboardController],
@@ -28,6 +29,7 @@ import { UpsModule } from '../ups/ups.module';
     VmModule,
     UserModule,
     RoomModule,
+    forwardRef(() => RoleModule),
     UpsModule,
   ],
 })

--- a/src/modules/dashboard/infrastructure/adapters/__tests__/setup-statistics.adapter.spec.ts
+++ b/src/modules/dashboard/infrastructure/adapters/__tests__/setup-statistics.adapter.spec.ts
@@ -6,6 +6,7 @@ describe('SetupStatisticsAdapter', () => {
   const upsRepo = { count: jest.fn() } as any;
   const serverRepo = { count: jest.fn() } as any;
   const vmRepo = { count: jest.fn() } as any;
+  const roleRepo = { count: jest.fn() } as any;
   let adapter: SetupStatisticsAdapter;
 
   beforeEach(() => {
@@ -16,6 +17,7 @@ describe('SetupStatisticsAdapter', () => {
       upsRepo,
       serverRepo,
       vmRepo,
+      roleRepo,
     );
   });
 
@@ -25,6 +27,7 @@ describe('SetupStatisticsAdapter', () => {
     upsRepo.count.mockResolvedValue(3);
     serverRepo.count.mockResolvedValue(5);
     vmRepo.count.mockResolvedValue(20);
+    roleRepo.count.mockResolvedValue(99);
 
     const result = await adapter.getStatistics();
 

--- a/src/modules/dashboard/infrastructure/adapters/setup-statistics.adapters.ts
+++ b/src/modules/dashboard/infrastructure/adapters/setup-statistics.adapters.ts
@@ -6,6 +6,7 @@ import { RoomRepositoryInterface } from '@/modules/rooms/domain/interfaces/room.
 import { UpsRepositoryInterface } from '@/modules/ups/domain/interfaces/ups.repository.interface';
 import { ServerRepositoryInterface } from '@/modules/servers/domain/interfaces/server.repository.interface';
 import { VmRepositoryInterface } from '@/modules/vms/domain/interfaces/vm.repository.interface';
+import { RoleTypeormRepository } from '@/modules/roles/infrastructure/repositories/role.typeorm.repository';
 
 @Injectable()
 export class SetupStatisticsAdapter implements StatisticsPort {
@@ -27,6 +28,9 @@ export class SetupStatisticsAdapter implements StatisticsPort {
 
     @Inject('VmRepositoryInterface')
     private readonly vmRepo: VmRepositoryInterface,
+
+    @Inject('RoleRepositoryInterface')
+    private readonly roleRepo: RoleTypeormRepository,
   ) {}
 
   /**
@@ -35,7 +39,9 @@ export class SetupStatisticsAdapter implements StatisticsPort {
   async getStatistics() {
     const [totalUsers, adminUsers] = await Promise.all([
       this.userRepo.count(),
-      99,
+      this.roleRepo.count({
+        where: { isAdmin: true },
+      }),
     ]);
 
     const [totalRooms, totalUps] = await Promise.all([

--- a/src/modules/history/application/controllers/__tests__/history.controller.spec.ts
+++ b/src/modules/history/application/controllers/__tests__/history.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HistoryController } from '../history.controller';
 import { GetHistoryListUseCase } from '../../use-cases/get-history-list.use-case';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
+import { RoleGuard } from '@/core/guards/role.guard';
 
 describe('HistoryController', () => {
   let controller: HistoryController;
@@ -8,11 +10,18 @@ describe('HistoryController', () => {
 
   beforeEach(async () => {
     getList = { execute: jest.fn() } as any;
+    const mockJwtGuard = { canActivate: jest.fn().mockReturnValue(true) };
+    const mockRoleGuard = { canActivate: jest.fn().mockReturnValue(true) };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HistoryController],
       providers: [{ provide: GetHistoryListUseCase, useValue: getList }],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtGuard)
+      .overrideGuard(RoleGuard)
+      .useValue(mockRoleGuard)
+      .compile();
 
     controller = module.get(HistoryController);
   });
@@ -21,7 +30,7 @@ describe('HistoryController', () => {
     const mock = { items: [] } as any;
     getList.execute.mockResolvedValue(mock);
     const result = await controller.getHistory('2', '5');
-    expect(getList.execute).toHaveBeenCalledWith(2, 5);
+    expect(getList.execute).toHaveBeenCalledWith(2, 5, {});
     expect(result).toBe(mock);
   });
 
@@ -29,7 +38,28 @@ describe('HistoryController', () => {
     const mock = { items: [] } as any;
     getList.execute.mockResolvedValue(mock);
     const result = await controller.getHistory();
-    expect(getList.execute).toHaveBeenCalledWith(1, 10);
+    expect(getList.execute).toHaveBeenCalledWith(1, 10, {});
     expect(result).toBe(mock);
+  });
+
+  it('passes filters to use case', async () => {
+    const mock = { items: [] } as any;
+    getList.execute.mockResolvedValue(mock);
+    await controller.getHistory(
+      '1',
+      '10',
+      'CREATE',
+      'role',
+      'user',
+      '2024-01-01',
+      '2024-01-31',
+    );
+    expect(getList.execute).toHaveBeenCalledWith(1, 10, {
+      action: 'CREATE',
+      entity: 'role',
+      userId: 'user',
+      from: new Date('2024-01-01'),
+      to: new Date('2024-01-31'),
+    });
   });
 });

--- a/src/modules/history/application/controllers/__tests__/history.controller.spec.ts
+++ b/src/modules/history/application/controllers/__tests__/history.controller.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HistoryController } from '../history.controller';
+import { GetHistoryListUseCase } from '../../use-cases/get-history-list.use-case';
+
+describe('HistoryController', () => {
+  let controller: HistoryController;
+  let getList: jest.Mocked<GetHistoryListUseCase>;
+
+  beforeEach(async () => {
+    getList = { execute: jest.fn() } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HistoryController],
+      providers: [{ provide: GetHistoryListUseCase, useValue: getList }],
+    }).compile();
+
+    controller = module.get(HistoryController);
+  });
+
+  it('returns paginated history', async () => {
+    const mock = { items: [] } as any;
+    getList.execute.mockResolvedValue(mock);
+    const result = await controller.getHistory('2', '5');
+    expect(getList.execute).toHaveBeenCalledWith(2, 5);
+    expect(result).toBe(mock);
+  });
+
+  it('uses defaults', async () => {
+    const mock = { items: [] } as any;
+    getList.execute.mockResolvedValue(mock);
+    const result = await controller.getHistory();
+    expect(getList.execute).toHaveBeenCalledWith(1, 10);
+    expect(result).toBe(mock);
+  });
+});

--- a/src/modules/history/application/controllers/history.controller.ts
+++ b/src/modules/history/application/controllers/history.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards, UseFilters } from '@nestjs/common';
 import {
   ApiTags,
   ApiQuery,
@@ -10,6 +10,8 @@ import { GetHistoryListUseCase } from '../use-cases/get-history-list.use-case';
 import { HistoryListResponseDto } from '../dto/history.list.response.dto';
 import { RoleGuard } from '@/core/guards';
 import { RequireRole } from '@/core/decorators/role.decorator';
+import { InvalidQueryExceptionFilter } from '@/core/filters/invalid-query.exception.filter';
+import { HistoryListFilters } from '../../domain/interfaces/history-filter.interface';
 
 @ApiTags('History')
 @Controller('history')
@@ -19,14 +21,32 @@ export class HistoryController {
   @Get()
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'action', required: false, type: String })
+  @ApiQuery({ name: 'entity', required: false, type: String })
+  @ApiQuery({ name: 'userId', required: false, type: String })
+  @ApiQuery({ name: 'from', required: false, type: String })
+  @ApiQuery({ name: 'to', required: false, type: String })
   @UseGuards(JwtAuthGuard, RoleGuard)
+  @UseFilters(InvalidQueryExceptionFilter)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get paginated history events' })
   @RequireRole({ isAdmin: true })
   async getHistory(
     @Query('page') page = '1',
     @Query('limit') limit = '10',
+    @Query('action') action?: string,
+    @Query('entity') entity?: string,
+    @Query('userId') userId?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
   ): Promise<HistoryListResponseDto> {
-    return this.getList.execute(Number(page), Number(limit));
+    const filters: HistoryListFilters = {};
+    if (action) filters.action = action;
+    if (entity) filters.entity = entity;
+    if (userId) filters.userId = userId;
+    if (from) filters.from = new Date(from);
+    if (to) filters.to = new Date(to);
+
+    return this.getList.execute(Number(page), Number(limit), filters);
   }
 }

--- a/src/modules/history/application/controllers/history.controller.ts
+++ b/src/modules/history/application/controllers/history.controller.ts
@@ -1,8 +1,15 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiQuery, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiQuery,
+  ApiOperation,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
 import { GetHistoryListUseCase } from '../use-cases/get-history-list.use-case';
 import { HistoryListResponseDto } from '../dto/history.list.response.dto';
+import { RoleGuard } from '@/core/guards';
+import { RequireRole } from '@/core/decorators/role.decorator';
 
 @ApiTags('History')
 @Controller('history')
@@ -12,9 +19,10 @@ export class HistoryController {
   @Get()
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RoleGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get paginated history events' })
+  @RequireRole({ isAdmin: true })
   async getHistory(
     @Query('page') page = '1',
     @Query('limit') limit = '10',

--- a/src/modules/history/application/controllers/history.controller.ts
+++ b/src/modules/history/application/controllers/history.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiQuery, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
+import { GetHistoryListUseCase } from '../use-cases/get-history-list.use-case';
+import { HistoryListResponseDto } from '../dto/history.list.response.dto';
+
+@ApiTags('History')
+@Controller('history')
+export class HistoryController {
+  constructor(private readonly getList: GetHistoryListUseCase) {}
+
+  @Get()
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get paginated history events' })
+  async getHistory(
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+  ): Promise<HistoryListResponseDto> {
+    return this.getList.execute(Number(page), Number(limit));
+  }
+}

--- a/src/modules/history/application/dto/history-event.response.dto.ts
+++ b/src/modules/history/application/dto/history-event.response.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID, IsString, IsOptional, IsDate } from 'class-validator';
+import { HistoryEvent } from '../../domain/entities/history-event.entity';
+import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
+import { Type } from 'class-transformer';
+
+export class HistoryEventResponseDto {
+  @ApiProperty()
+  @IsUUID()
+  readonly id: string;
+
+  @ApiProperty()
+  @IsString()
+  readonly entity: string;
+
+  @ApiProperty()
+  @IsString()
+  readonly entityId: string;
+
+  @ApiProperty()
+  @IsString()
+  readonly action: string;
+
+  @ApiProperty({ required: false })
+  @IsUUID()
+  @IsOptional()
+  readonly userId?: string;
+
+  @ApiProperty()
+  @IsDate()
+  readonly createdAt: Date;
+
+  @ApiProperty({ required: false, type: () => UserResponseDto })
+  @IsOptional()
+  @Type(() => UserResponseDto)
+  readonly user?: UserResponseDto;
+
+  constructor(event: HistoryEvent) {
+    this.id = event.id;
+    this.entity = event.entity;
+    this.entityId = event.entityId;
+    this.action = event.action;
+    this.userId = event.userId;
+    this.createdAt = event.createdAt;
+    if (event.user) {
+      this.user = new UserResponseDto(event.user);
+    }
+  }
+}

--- a/src/modules/history/application/dto/history.list.response.dto.ts
+++ b/src/modules/history/application/dto/history.list.response.dto.ts
@@ -1,0 +1,8 @@
+import { PaginatedResponseDto } from '@/core/dto';
+import { HistoryEventResponseDto } from './history-event.response.dto';
+
+export class HistoryListResponseDto extends PaginatedResponseDto<HistoryEventResponseDto> {
+  constructor(items: HistoryEventResponseDto[], total: number, page: number, limit: number) {
+    super(items, total, page, limit);
+  }
+}

--- a/src/modules/history/application/dto/history.list.response.dto.ts
+++ b/src/modules/history/application/dto/history.list.response.dto.ts
@@ -2,7 +2,12 @@ import { PaginatedResponseDto } from '@/core/dto';
 import { HistoryEventResponseDto } from './history-event.response.dto';
 
 export class HistoryListResponseDto extends PaginatedResponseDto<HistoryEventResponseDto> {
-  constructor(items: HistoryEventResponseDto[], total: number, page: number, limit: number) {
+  constructor(
+    items: HistoryEventResponseDto[],
+    total: number,
+    page: number,
+    limit: number,
+  ) {
     super(items, total, page, limit);
   }
 }

--- a/src/modules/history/application/use-cases/__tests__/get-history-list.use-case.spec.ts
+++ b/src/modules/history/application/use-cases/__tests__/get-history-list.use-case.spec.ts
@@ -19,9 +19,19 @@ describe('GetHistoryListUseCase', () => {
 
     const result = await useCase.execute(2, 5);
 
-    expect(repo.paginate).toHaveBeenCalledWith(2, 5, ['user']);
+    expect(repo.paginate).toHaveBeenCalledWith(2, 5, ['user'], {});
     expect(result.totalItems).toBe(1);
     expect(result.currentPage).toBe(2);
+  });
+
+  it('passes filters to repository', async () => {
+    const events = [new HistoryEvent()];
+    repo.paginate.mockResolvedValue([events, 1]);
+
+    const filters = { action: 'CREATE', userId: '123' };
+    await useCase.execute(1, 10, filters);
+
+    expect(repo.paginate).toHaveBeenCalledWith(1, 10, ['user'], filters);
   });
 
   it('returns empty list when no events', async () => {

--- a/src/modules/history/application/use-cases/__tests__/get-history-list.use-case.spec.ts
+++ b/src/modules/history/application/use-cases/__tests__/get-history-list.use-case.spec.ts
@@ -1,0 +1,35 @@
+import { GetHistoryListUseCase } from '../get-history-list.use-case';
+import { HistoryRepositoryInterface } from '@/modules/history/domain/interfaces/history.repository.interface';
+import { HistoryEvent } from '@/modules/history/domain/entities/history-event.entity';
+
+describe('GetHistoryListUseCase', () => {
+  let useCase: GetHistoryListUseCase;
+  let repo: jest.Mocked<HistoryRepositoryInterface>;
+
+  beforeEach(() => {
+    repo = {
+      paginate: jest.fn(),
+    } as any;
+    useCase = new GetHistoryListUseCase(repo);
+  });
+
+  it('returns paginated history events', async () => {
+    const events = [new HistoryEvent()];
+    repo.paginate.mockResolvedValue([events, 1]);
+
+    const result = await useCase.execute(2, 5);
+
+    expect(repo.paginate).toHaveBeenCalledWith(2, 5, ['user']);
+    expect(result.totalItems).toBe(1);
+    expect(result.currentPage).toBe(2);
+  });
+
+  it('returns empty list when no events', async () => {
+    repo.paginate.mockResolvedValue([[], 0]);
+
+    const result = await useCase.execute();
+
+    expect(result.items).toEqual([]);
+    expect(result.totalItems).toBe(0);
+  });
+});

--- a/src/modules/history/application/use-cases/__tests__/log-history.use-case.spec.ts
+++ b/src/modules/history/application/use-cases/__tests__/log-history.use-case.spec.ts
@@ -1,0 +1,30 @@
+import { LogHistoryUseCase } from '../log-history.use-case';
+import { HistoryRepositoryInterface } from '@/modules/history/domain/interfaces/history.repository.interface';
+
+describe('LogHistoryUseCase', () => {
+  let repo: jest.Mocked<HistoryRepositoryInterface>;
+  let useCase: LogHistoryUseCase;
+
+  beforeEach(() => {
+    repo = {
+      save: jest.fn(),
+    } as any;
+    useCase = new LogHistoryUseCase(repo);
+  });
+
+  it('saves event with provided data', async () => {
+    await useCase.execute('user', 'id1', 'CREATE', 'userId');
+    expect(repo.save).toHaveBeenCalled();
+    const event = repo.save.mock.calls[0][0];
+    expect(event.entity).toBe('user');
+    expect(event.entityId).toBe('id1');
+    expect(event.action).toBe('CREATE');
+    expect(event.userId).toBe('userId');
+  });
+
+  it('saves event without optional userId', async () => {
+    await useCase.execute('user', 'id1', 'CREATE');
+    const event = repo.save.mock.calls[0][0];
+    expect(event.userId).toBeUndefined();
+  });
+});

--- a/src/modules/history/application/use-cases/get-history-list.use-case.ts
+++ b/src/modules/history/application/use-cases/get-history-list.use-case.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
 import { HistoryEventResponseDto } from '../dto/history-event.response.dto';
 import { HistoryListResponseDto } from '../dto/history.list.response.dto';
+import { HistoryListFilters } from '../../domain/interfaces/history-filter.interface';
 
 @Injectable()
 export class GetHistoryListUseCase {
@@ -10,8 +11,17 @@ export class GetHistoryListUseCase {
     private readonly repo: HistoryRepositoryInterface,
   ) {}
 
-  async execute(page = 1, limit = 10): Promise<HistoryListResponseDto> {
-    const [events, total] = await this.repo.paginate(page, limit, ['user']);
+  async execute(
+    page = 1,
+    limit = 10,
+    filters: HistoryListFilters = {},
+  ): Promise<HistoryListResponseDto> {
+    const [events, total] = await this.repo.paginate(
+      page,
+      limit,
+      ['user'],
+      filters,
+    );
     const dtos = events.map((e) => new HistoryEventResponseDto(e));
     return new HistoryListResponseDto(dtos, total, page, limit);
   }

--- a/src/modules/history/application/use-cases/get-history-list.use-case.ts
+++ b/src/modules/history/application/use-cases/get-history-list.use-case.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+import { HistoryEventResponseDto } from '../dto/history-event.response.dto';
+import { HistoryListResponseDto } from '../dto/history.list.response.dto';
+
+@Injectable()
+export class GetHistoryListUseCase {
+  constructor(
+    @Inject('HistoryRepositoryInterface')
+    private readonly repo: HistoryRepositoryInterface,
+  ) {}
+
+  async execute(page = 1, limit = 10): Promise<HistoryListResponseDto> {
+    const [events, total] = await this.repo.paginate(page, limit, ['user']);
+    const dtos = events.map((e) => new HistoryEventResponseDto(e));
+    return new HistoryListResponseDto(dtos, total, page, limit);
+  }
+}

--- a/src/modules/history/application/use-cases/get-history-stats.use-case.ts
+++ b/src/modules/history/application/use-cases/get-history-stats.use-case.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+
+@Injectable()
+export class GetHistoryStatsUseCase {
+  constructor(
+    @Inject('HistoryRepositoryInterface')
+    private readonly repo: HistoryRepositoryInterface,
+  ) {}
+
+  async execute(entity: string, months: number): Promise<Record<string, number>> {
+    return this.repo.countCreatedByMonth(entity, months);
+  }
+}

--- a/src/modules/history/application/use-cases/get-history-stats.use-case.ts
+++ b/src/modules/history/application/use-cases/get-history-stats.use-case.ts
@@ -8,7 +8,10 @@ export class GetHistoryStatsUseCase {
     private readonly repo: HistoryRepositoryInterface,
   ) {}
 
-  async execute(entity: string, months: number): Promise<Record<string, number>> {
+  async execute(
+    entity: string,
+    months: number,
+  ): Promise<Record<string, number>> {
     return this.repo.countCreatedByMonth(entity, months);
   }
 }

--- a/src/modules/history/application/use-cases/index.ts
+++ b/src/modules/history/application/use-cases/index.ts
@@ -1,0 +1,2 @@
+export * from './log-history.use-case';
+export * from './get-history-stats.use-case';

--- a/src/modules/history/application/use-cases/index.ts
+++ b/src/modules/history/application/use-cases/index.ts
@@ -1,2 +1,3 @@
 export * from './log-history.use-case';
 export * from './get-history-stats.use-case';
+export * from './get-history-list.use-case';

--- a/src/modules/history/application/use-cases/log-history.use-case.ts
+++ b/src/modules/history/application/use-cases/log-history.use-case.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+import { HistoryEvent } from '../../domain/entities/history-event.entity';
+
+@Injectable()
+export class LogHistoryUseCase {
+  constructor(
+    @Inject('HistoryRepositoryInterface')
+    private readonly repo: HistoryRepositoryInterface,
+  ) {}
+
+  async execute(entity: string, entityId: string, action: string): Promise<void> {
+    const event = new HistoryEvent();
+    event.entity = entity;
+    event.entityId = entityId;
+    event.action = action;
+    await this.repo.save(event);
+  }
+}

--- a/src/modules/history/application/use-cases/log-history.use-case.ts
+++ b/src/modules/history/application/use-cases/log-history.use-case.ts
@@ -9,11 +9,19 @@ export class LogHistoryUseCase {
     private readonly repo: HistoryRepositoryInterface,
   ) {}
 
-  async execute(entity: string, entityId: string, action: string): Promise<void> {
+  async execute(
+    entity: string,
+    entityId: string,
+    action: string,
+    userId?: string,
+  ): Promise<void> {
     const event = new HistoryEvent();
     event.entity = entity;
     event.entityId = entityId;
     event.action = action;
+    if (userId) {
+      event.userId = userId;
+    }
     await this.repo.save(event);
   }
 }

--- a/src/modules/history/domain/entities/history-event.entity.ts
+++ b/src/modules/history/domain/entities/history-event.entity.ts
@@ -1,5 +1,14 @@
-import { BaseEntity, CreateDateColumn, Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import {
+  BaseEntity,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@/modules/users/domain/entities/user.entity';
 
 @Entity('history_event')
 export class HistoryEvent extends BaseEntity {
@@ -18,6 +27,15 @@ export class HistoryEvent extends BaseEntity {
   @ApiProperty({ description: 'Action performed like CREATE, UPDATE, DELETE' })
   @Column()
   action!: string;
+
+  @ApiProperty({ description: 'User who performed the action', required: false })
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'userId' })
+  user?: User;
+
+  @ApiProperty({ required: false })
+  @Column({ nullable: true })
+  userId?: string;
 
   @ApiProperty()
   @CreateDateColumn()

--- a/src/modules/history/domain/entities/history-event.entity.ts
+++ b/src/modules/history/domain/entities/history-event.entity.ts
@@ -28,7 +28,10 @@ export class HistoryEvent extends BaseEntity {
   @Column()
   action!: string;
 
-  @ApiProperty({ description: 'User who performed the action', required: false })
+  @ApiProperty({
+    description: 'User who performed the action',
+    required: false,
+  })
   @ManyToOne(() => User, { nullable: true })
   @JoinColumn({ name: 'userId' })
   user?: User;

--- a/src/modules/history/domain/entities/history-event.entity.ts
+++ b/src/modules/history/domain/entities/history-event.entity.ts
@@ -1,0 +1,25 @@
+import { BaseEntity, CreateDateColumn, Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('history_event')
+export class HistoryEvent extends BaseEntity {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ApiProperty({ description: 'Entity type, e.g. user, server' })
+  @Column()
+  entity!: string;
+
+  @ApiProperty({ description: 'Identifier of the entity instance' })
+  @Column()
+  entityId!: string;
+
+  @ApiProperty({ description: 'Action performed like CREATE, UPDATE, DELETE' })
+  @Column()
+  action!: string;
+
+  @ApiProperty()
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/src/modules/history/domain/interfaces/history-filter.interface.ts
+++ b/src/modules/history/domain/interfaces/history-filter.interface.ts
@@ -1,0 +1,7 @@
+export interface HistoryListFilters {
+  action?: string;
+  entity?: string;
+  userId?: string;
+  from?: Date;
+  to?: Date;
+}

--- a/src/modules/history/domain/interfaces/history.repository.interface.ts
+++ b/src/modules/history/domain/interfaces/history.repository.interface.ts
@@ -4,4 +4,9 @@ import { HistoryEvent } from '../entities/history-event.entity';
 export interface HistoryRepositoryInterface
   extends GenericRepositoryInterface<HistoryEvent> {
   countCreatedByMonth(entity: string, months: number): Promise<Record<string, number>>;
+  paginate(
+    page: number,
+    limit: number,
+    relations?: string[],
+  ): Promise<[HistoryEvent[], number]>;
 }

--- a/src/modules/history/domain/interfaces/history.repository.interface.ts
+++ b/src/modules/history/domain/interfaces/history.repository.interface.ts
@@ -1,5 +1,6 @@
 import { GenericRepositoryInterface } from '@/core/types/generic-repository.interface';
 import { HistoryEvent } from '../entities/history-event.entity';
+import { HistoryListFilters } from './history-filter.interface';
 
 export interface HistoryRepositoryInterface
   extends GenericRepositoryInterface<HistoryEvent> {
@@ -11,5 +12,6 @@ export interface HistoryRepositoryInterface
     page: number,
     limit: number,
     relations?: string[],
+    filters?: HistoryListFilters,
   ): Promise<[HistoryEvent[], number]>;
 }

--- a/src/modules/history/domain/interfaces/history.repository.interface.ts
+++ b/src/modules/history/domain/interfaces/history.repository.interface.ts
@@ -1,0 +1,7 @@
+import { GenericRepositoryInterface } from '@/core/types/generic-repository.interface';
+import { HistoryEvent } from '../entities/history-event.entity';
+
+export interface HistoryRepositoryInterface
+  extends GenericRepositoryInterface<HistoryEvent> {
+  countCreatedByMonth(entity: string, months: number): Promise<Record<string, number>>;
+}

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -2,18 +2,30 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HistoryEvent } from './domain/entities/history-event.entity';
 import { HistoryEventTypeormRepository } from './infrastructure/repositories/history-event.typeorm.repository';
-import { GetHistoryStatsUseCase, LogHistoryUseCase } from './application/use-cases';
+import {
+  GetHistoryStatsUseCase,
+  LogHistoryUseCase,
+  GetHistoryListUseCase,
+} from './application/use-cases';
+import { HistoryController } from './application/controllers/history.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([HistoryEvent])],
+  controllers: [HistoryController],
   providers: [
     LogHistoryUseCase,
     GetHistoryStatsUseCase,
+    GetHistoryListUseCase,
     {
       provide: 'HistoryRepositoryInterface',
       useClass: HistoryEventTypeormRepository,
     },
   ],
-  exports: [LogHistoryUseCase, GetHistoryStatsUseCase, 'HistoryRepositoryInterface'],
+  exports: [
+    LogHistoryUseCase,
+    GetHistoryStatsUseCase,
+    GetHistoryListUseCase,
+    'HistoryRepositoryInterface',
+  ],
 })
 export class HistoryModule {}

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HistoryEvent } from './domain/entities/history-event.entity';
 import { HistoryEventTypeormRepository } from './infrastructure/repositories/history-event.typeorm.repository';
@@ -8,9 +8,13 @@ import {
   GetHistoryListUseCase,
 } from './application/use-cases';
 import { HistoryController } from './application/controllers/history.controller';
+import { UserModule } from '../users/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([HistoryEvent])],
+  imports: [
+    TypeOrmModule.forFeature([HistoryEvent]),
+    forwardRef(() => UserModule),
+  ],
   controllers: [HistoryController],
   providers: [
     LogHistoryUseCase,

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -1,35 +1,16 @@
-import { forwardRef, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { HistoryEvent } from './domain/entities/history-event.entity';
-import { HistoryEventTypeormRepository } from './infrastructure/repositories/history-event.typeorm.repository';
+import { Module, forwardRef } from '@nestjs/common';
 import {
   GetHistoryStatsUseCase,
-  LogHistoryUseCase,
   GetHistoryListUseCase,
 } from './application/use-cases';
 import { HistoryController } from './application/controllers/history.controller';
+import { AuditModule } from '../audit/audit.module';
 import { UserModule } from '../users/user.module';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([HistoryEvent]),
-    forwardRef(() => UserModule),
-  ],
+  imports: [AuditModule, forwardRef(() => UserModule)],
   controllers: [HistoryController],
-  providers: [
-    LogHistoryUseCase,
-    GetHistoryStatsUseCase,
-    GetHistoryListUseCase,
-    {
-      provide: 'HistoryRepositoryInterface',
-      useClass: HistoryEventTypeormRepository,
-    },
-  ],
-  exports: [
-    LogHistoryUseCase,
-    GetHistoryStatsUseCase,
-    GetHistoryListUseCase,
-    'HistoryRepositoryInterface',
-  ],
+  providers: [GetHistoryStatsUseCase, GetHistoryListUseCase],
+  exports: [GetHistoryStatsUseCase, GetHistoryListUseCase],
 })
 export class HistoryModule {}

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HistoryEvent } from './domain/entities/history-event.entity';
+import { HistoryEventTypeormRepository } from './infrastructure/repositories/history-event.typeorm.repository';
+import { GetHistoryStatsUseCase, LogHistoryUseCase } from './application/use-cases';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([HistoryEvent])],
+  providers: [
+    LogHistoryUseCase,
+    GetHistoryStatsUseCase,
+    {
+      provide: 'HistoryRepositoryInterface',
+      useClass: HistoryEventTypeormRepository,
+    },
+  ],
+  exports: [LogHistoryUseCase, GetHistoryStatsUseCase, 'HistoryRepositoryInterface'],
+})
+export class HistoryModule {}

--- a/src/modules/history/infrastructure/repositories/history-event.typeorm.repository.ts
+++ b/src/modules/history/infrastructure/repositories/history-event.typeorm.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { HistoryEvent } from '../../domain/entities/history-event.entity';
+import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+
+@Injectable()
+export class HistoryEventTypeormRepository
+  extends Repository<HistoryEvent>
+  implements HistoryRepositoryInterface
+{
+  constructor(private readonly dataSource: DataSource) {
+    super(HistoryEvent, dataSource.createEntityManager());
+  }
+
+  async count(): Promise<number> {
+    return this.repository.count();
+  }
+
+  private get repository(): Repository<HistoryEvent> {
+    return this.dataSource.getRepository(HistoryEvent);
+  }
+
+  async save(entity: HistoryEvent): Promise<HistoryEvent> {
+    return this.repository.save(entity);
+  }
+
+  async findAll(): Promise<HistoryEvent[]> {
+    return this.repository.find();
+  }
+
+  async findOneByField<K extends keyof HistoryEvent>({
+    field,
+    value,
+  }: {
+    field: K;
+    value: HistoryEvent[K];
+  }): Promise<HistoryEvent | null> {
+    return this.repository.findOne({ where: { [field]: value } as any });
+  }
+
+  async countCreatedByMonth(
+    entity: string,
+    months: number,
+  ): Promise<Record<string, number>> {
+    const qb = this.repository
+      .createQueryBuilder('history')
+      .select("to_char(history.createdAt, 'YYYY-MM')", 'month')
+      .addSelect('COUNT(*)', 'count')
+      .where('history.entity = :entity', { entity })
+      .andWhere('history.action = :action', { action: 'CREATE' })
+      .andWhere(`history.createdAt >= NOW() - INTERVAL '${months} months'`)
+      .groupBy('month')
+      .orderBy('month', 'ASC');
+
+    const results = await qb.getRawMany<{ month: string; count: string }>();
+    return results.reduce<Record<string, number>>((acc, curr) => {
+      acc[curr.month] = Number(curr.count);
+      return acc;
+    }, {});
+  }
+}

--- a/src/modules/history/infrastructure/repositories/history-event.typeorm.repository.ts
+++ b/src/modules/history/infrastructure/repositories/history-event.typeorm.repository.ts
@@ -58,4 +58,17 @@ export class HistoryEventTypeormRepository
       return acc;
     }, {});
   }
+
+  async paginate(
+    page: number,
+    limit: number,
+    relations: string[] = [],
+  ): Promise<[HistoryEvent[], number]> {
+    return this.repository.findAndCount({
+      relations,
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { createdAt: 'DESC' },
+    });
+  }
 }

--- a/src/modules/roles/__mocks__/role.mock.ts
+++ b/src/modules/roles/__mocks__/role.mock.ts
@@ -12,6 +12,7 @@ export const createMockRole = (overrides: Partial<Role> = {}): Role => {
     permissionServers: [createMockPermissionServer()],
     permissionVms: [createMockPermissionVm()],
     canCreateServer: true,
+    isAdmin: true,
     ...overrides,
   };
   return Object.assign(new Role(), base);

--- a/src/modules/roles/application/dto/__tests__/role.response.dto.spec.ts
+++ b/src/modules/roles/application/dto/__tests__/role.response.dto.spec.ts
@@ -11,6 +11,8 @@ describe('RoleResponseDto', () => {
     expect(Array.isArray(dto.permissionVms)).toBe(true);
     expect(dto.permissionServers.length).toBe(role.permissionServers.length);
     expect(dto.permissionVms.length).toBe(role.permissionVms.length);
+    expect(dto.canCreateServer).toBe(role.canCreateServer);
+    expect(dto.isAdmin).toBe(role.isAdmin);
   });
 
   it('should work with empty permissions', () => {
@@ -18,5 +20,7 @@ describe('RoleResponseDto', () => {
     const dto = new RoleResponseDto(role);
     expect(dto.permissionServers).toEqual([]);
     expect(dto.permissionVms).toEqual([]);
+    expect(dto.canCreateServer).toBe(role.canCreateServer);
+    expect(dto.isAdmin).toBe(role.isAdmin);
   });
 });

--- a/src/modules/roles/application/dto/role.dto.ts
+++ b/src/modules/roles/application/dto/role.dto.ts
@@ -30,4 +30,8 @@ export class RoleDto {
   @ApiProperty()
   @IsBoolean()
   canCreateServer: boolean;
+
+  @ApiProperty()
+  @IsBoolean()
+  isAdmin: boolean;
 }

--- a/src/modules/roles/application/dto/role.response.dto.ts
+++ b/src/modules/roles/application/dto/role.response.dto.ts
@@ -40,5 +40,7 @@ export class RoleResponseDto {
     this.permissionVms = (role.permissionVms ?? []).map(
       (permission) => new PermissionVmDto(permission),
     );
+    this.canCreateServer = role.canCreateServer;
+    this.isAdmin = role.isAdmin;
   }
 }

--- a/src/modules/roles/application/dto/role.response.dto.ts
+++ b/src/modules/roles/application/dto/role.response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { Role } from '../../domain/entities/role.entity';
 import { PermissionVmDto } from '../../../permissions/application/dto/permission.vm.dto';
 import { PermissionServerDto } from '../../../permissions/application/dto/permission.server.dto';
@@ -20,6 +20,16 @@ export class RoleResponseDto {
 
   @ApiProperty({ type: () => PermissionVmDto, isArray: true })
   readonly permissionVms: PermissionVmDto[];
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsBoolean()
+  readonly canCreateServer!: boolean;
+
+  @ApiProperty()
+  @IsNotEmpty()
+  @IsBoolean()
+  readonly isAdmin!: boolean;
 
   constructor(role: Role) {
     this.id = role.id;

--- a/src/modules/roles/application/use-cases/__tests__/ensure-default-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/ensure-default-role.use-case.spec.ts
@@ -29,7 +29,7 @@ describe('EnsureDefaultRoleUseCase', () => {
 
     const admin = createMockRole({
       name: 'ADMIN',
-      canCreateServer: true,
+      canCreateServer: false,
       isAdmin: true,
     });
     roleRepository.createRole.mockResolvedValue(admin);
@@ -47,7 +47,7 @@ describe('EnsureDefaultRoleUseCase', () => {
 
     const admin = createMockRole({
       name: 'ADMIN',
-      canCreateServer: true,
+      canCreateServer: false,
       isAdmin: true,
     });
     roleRepository.findAll.mockResolvedValue([admin]);

--- a/src/modules/roles/application/use-cases/__tests__/ensure-default-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/ensure-default-role.use-case.spec.ts
@@ -27,7 +27,11 @@ describe('EnsureDefaultRoleUseCase', () => {
     roleRepository.findAll.mockResolvedValue([]);
     getUserCountUseCase.execute.mockResolvedValue(0);
 
-    const admin = createMockRole({ name: 'ADMIN', canCreateServer: true });
+    const admin = createMockRole({
+      name: 'ADMIN',
+      canCreateServer: true,
+      isAdmin: true,
+    });
     roleRepository.createRole.mockResolvedValue(admin);
     roleRepository.save.mockResolvedValue(admin);
 
@@ -41,11 +45,19 @@ describe('EnsureDefaultRoleUseCase', () => {
   it('should update admin rights if userCount = 0 and admin canCreateServer is false', async () => {
     getUserCountUseCase.execute.mockResolvedValue(0);
 
-    const admin = createMockRole({ name: 'ADMIN', canCreateServer: false });
+    const admin = createMockRole({
+      name: 'ADMIN',
+      canCreateServer: true,
+      isAdmin: true,
+    });
     roleRepository.findAll.mockResolvedValue([admin]);
     roleRepository.findOneByField.mockResolvedValue(admin);
 
-    const updatedAdmin = createMockRole({ ...admin, canCreateServer: true });
+    const updatedAdmin = createMockRole({
+      ...admin,
+      canCreateServer: true,
+      isAdmin: true,
+    });
     roleRepository.save.mockResolvedValue(updatedAdmin);
 
     const result = await useCase.execute();

--- a/src/modules/roles/application/use-cases/ensure-default-role.use-case.ts
+++ b/src/modules/roles/application/use-cases/ensure-default-role.use-case.ts
@@ -24,6 +24,7 @@ export class EnsureDefaultRoleUseCase {
       this.logger.warn('Création rôle ADMIN par défaut');
       const admin = await this.roleRepository.createRole('ADMIN');
       admin.canCreateServer = true;
+      admin.isAdmin = true;
       return this.roleRepository.save(admin);
     }
 

--- a/src/modules/roles/domain/entities/role.entity.ts
+++ b/src/modules/roles/domain/entities/role.entity.ts
@@ -32,4 +32,7 @@ export class Role extends BaseEntity {
 
   @Column({ type: 'boolean', default: false })
   canCreateServer: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  isAdmin: boolean;
 }

--- a/src/modules/roles/role.module.ts
+++ b/src/modules/roles/role.module.ts
@@ -23,6 +23,6 @@ import { RoleUseCases } from './application/use-cases';
       useClass: RoleTypeormRepository,
     },
   ],
-  exports: [...RoleUseCases, RoleDomainService],
+  exports: [...RoleUseCases, RoleDomainService, 'RoleRepositoryInterface'],
 })
 export class RoleModule {}

--- a/src/modules/rooms/application/controllers/room.controller.spec.ts
+++ b/src/modules/rooms/application/controllers/room.controller.spec.ts
@@ -11,6 +11,7 @@ import {
   mockRoomCreationDto,
   mockRoomResponseDto,
 } from '@/modules/rooms/__mocks__';
+import { JwtPayload } from '@/core/types/jwt-payload.interface';
 
 describe('RoomController', () => {
   let controller: RoomController;
@@ -22,6 +23,11 @@ describe('RoomController', () => {
   const deleteRoomUseCase = { execute: jest.fn() };
 
   const mockRoomResponse = mockRoomResponseDto();
+
+  const mockPayload: JwtPayload = {
+    userId: 'user-123',
+    email: 'john.doe@example.com',
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -63,10 +69,10 @@ describe('RoomController', () => {
     createRoomUseCase.execute.mockResolvedValue(mockRoomResponse);
     const dto = mockRoomCreationDto();
 
-    const result = await controller.createRoom(dto);
+    const result = await controller.createRoom(mockPayload, dto);
 
     expect(result).toEqual(mockRoomResponse);
-    expect(createRoomUseCase.execute).toHaveBeenCalledWith(dto);
+    expect(createRoomUseCase.execute).toHaveBeenCalledWith(mockPayload, dto);
     expect(createRoomUseCase.execute).toHaveBeenCalledTimes(1);
   });
 
@@ -74,17 +80,21 @@ describe('RoomController', () => {
     updateRoomUseCase.execute.mockResolvedValue(mockRoomResponse);
     const dto = mockRoomCreationDto();
 
-    const result = await controller.updateRoom('uuid-test', dto);
+    const result = await controller.updateRoom('uuid-test', dto, mockPayload);
 
     expect(result).toEqual(mockRoomResponse);
-    expect(updateRoomUseCase.execute).toHaveBeenCalledWith('uuid-test', dto);
+    expect(updateRoomUseCase.execute).toHaveBeenCalledWith(
+      'uuid-test',
+      dto,
+      mockPayload,
+    );
     expect(updateRoomUseCase.execute).toHaveBeenCalledTimes(1);
   });
 
   it('should delete a room when deleteRoom is called', async () => {
     deleteRoomUseCase.execute.mockResolvedValue(undefined);
 
-    const result = await controller.deleteRoom('uuid-test');
+    const result = await controller.deleteRoom('uuid-test', mockPayload);
 
     expect(result).toEqual(undefined);
     expect(deleteRoomUseCase.execute).toHaveBeenCalledWith('uuid-test');

--- a/src/modules/rooms/application/controllers/room.controller.spec.ts
+++ b/src/modules/rooms/application/controllers/room.controller.spec.ts
@@ -56,7 +56,7 @@ describe('RoomController', () => {
   it('should return a room by ID when getRoomById is called', async () => {
     getRoomByIdUseCase.execute.mockResolvedValue(mockRoomResponse);
 
-    const req: any = { user: { userId: 'u1' } };
+    const req: any = { userId: 'u1', email: 'e@test.com' };
 
     const result = await controller.getRoomById('uuid-test', req);
 
@@ -72,7 +72,10 @@ describe('RoomController', () => {
     const result = await controller.createRoom(mockPayload, dto);
 
     expect(result).toEqual(mockRoomResponse);
-    expect(createRoomUseCase.execute).toHaveBeenCalledWith(mockPayload, dto);
+    expect(createRoomUseCase.execute).toHaveBeenCalledWith(
+      dto,
+      mockPayload.userId,
+    );
     expect(createRoomUseCase.execute).toHaveBeenCalledTimes(1);
   });
 
@@ -86,7 +89,7 @@ describe('RoomController', () => {
     expect(updateRoomUseCase.execute).toHaveBeenCalledWith(
       'uuid-test',
       dto,
-      mockPayload,
+      mockPayload.userId,
     );
     expect(updateRoomUseCase.execute).toHaveBeenCalledTimes(1);
   });
@@ -97,7 +100,10 @@ describe('RoomController', () => {
     const result = await controller.deleteRoom('uuid-test', mockPayload);
 
     expect(result).toEqual(undefined);
-    expect(deleteRoomUseCase.execute).toHaveBeenCalledWith('uuid-test');
+    expect(deleteRoomUseCase.execute).toHaveBeenCalledWith(
+      'uuid-test',
+      mockPayload.userId,
+    );
     expect(deleteRoomUseCase.execute).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/rooms/application/controllers/room.controller.ts
+++ b/src/modules/rooms/application/controllers/room.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   Param,
   ParseUUIDPipe,
-  Req,
   Patch,
   Post,
   UseGuards,
@@ -19,7 +18,6 @@ import {
 } from '@nestjs/swagger';
 
 import { RoomCreationDto, RoomResponseDto } from '../dto';
-import { ExpressRequestWithUser } from '@/core/types/express-with-user.interface';
 import {
   CreateRoomUseCase,
   DeleteRoomUseCase,

--- a/src/modules/rooms/application/use-cases/create-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/create-room.use-case.ts
@@ -11,9 +11,9 @@ export class CreateRoomUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(dto: RoomCreationDto): Promise<RoomResponseDto> {
+  async execute(dto: RoomCreationDto, userId?: string): Promise<RoomResponseDto> {
     const room = await this.roomRepository.createRoom(dto.name);
-    await this.logHistory?.execute('room', room.id, 'CREATE');
+    await this.logHistory?.execute('room', room.id, 'CREATE', userId);
     return RoomResponseDto.from(room);
   }
 }

--- a/src/modules/rooms/application/use-cases/create-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/create-room.use-case.ts
@@ -1,16 +1,19 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { RoomRepositoryInterface } from '../../domain/interfaces/room.repository.interface';
 import { RoomResponseDto, RoomCreationDto } from '../dto';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class CreateRoomUseCase {
   constructor(
     @Inject('RoomRepositoryInterface')
     private readonly roomRepository: RoomRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(dto: RoomCreationDto): Promise<RoomResponseDto> {
     const room = await this.roomRepository.createRoom(dto.name);
+    await this.logHistory?.execute('room', room.id, 'CREATE');
     return RoomResponseDto.from(room);
   }
 }

--- a/src/modules/rooms/application/use-cases/create-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/create-room.use-case.ts
@@ -11,7 +11,10 @@ export class CreateRoomUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(dto: RoomCreationDto, userId?: string): Promise<RoomResponseDto> {
+  async execute(
+    dto: RoomCreationDto,
+    userId?: string,
+  ): Promise<RoomResponseDto> {
     const room = await this.roomRepository.createRoom(dto.name);
     await this.logHistory?.execute('room', room.id, 'CREATE', userId);
     return RoomResponseDto.from(room);

--- a/src/modules/rooms/application/use-cases/delete-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/delete-room.use-case.ts
@@ -10,8 +10,8 @@ export class DeleteRoomUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string): Promise<void> {
+  async execute(id: string, userId?: string): Promise<void> {
     await this.roomRepository.deleteRoom(id);
-    await this.logHistory?.execute('room', id, 'DELETE');
+    await this.logHistory?.execute('room', id, 'DELETE', userId);
   }
 }

--- a/src/modules/rooms/application/use-cases/delete-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/delete-room.use-case.ts
@@ -1,14 +1,17 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { RoomRepositoryInterface } from '../../domain/interfaces/room.repository.interface';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class DeleteRoomUseCase {
   constructor(
     @Inject('RoomRepositoryInterface')
     private readonly roomRepository: RoomRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
     await this.roomRepository.deleteRoom(id);
+    await this.logHistory?.execute('room', id, 'DELETE');
   }
 }

--- a/src/modules/rooms/application/use-cases/update-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/update-room.use-case.ts
@@ -1,16 +1,19 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { RoomRepositoryInterface } from '../../domain/interfaces/room.repository.interface';
 import { RoomResponseDto, RoomCreationDto } from '../dto';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class UpdateRoomUseCase {
   constructor(
     @Inject('RoomRepositoryInterface')
     private readonly roomRepository: RoomRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string, dto: RoomCreationDto): Promise<RoomResponseDto> {
     const room = await this.roomRepository.updateRoom(id, dto.name);
+    await this.logHistory?.execute('room', room.id, 'UPDATE');
     return RoomResponseDto.from(room);
   }
 }

--- a/src/modules/rooms/application/use-cases/update-room.use-case.ts
+++ b/src/modules/rooms/application/use-cases/update-room.use-case.ts
@@ -11,9 +11,13 @@ export class UpdateRoomUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string, dto: RoomCreationDto): Promise<RoomResponseDto> {
+  async execute(
+    id: string,
+    dto: RoomCreationDto,
+    userId?: string,
+  ): Promise<RoomResponseDto> {
     const room = await this.roomRepository.updateRoom(id, dto.name);
-    await this.logHistory?.execute('room', room.id, 'UPDATE');
+    await this.logHistory?.execute('room', room.id, 'UPDATE', userId);
     return RoomResponseDto.from(room);
   }
 }

--- a/src/modules/rooms/room.module.ts
+++ b/src/modules/rooms/room.module.ts
@@ -5,7 +5,7 @@ import { Room } from './domain/entities/room.entity';
 import { RoomTypeormRepository } from './infrastructure/repositories/room.typeorm.repository';
 import { RoomUseCases } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 import { PermissionModule } from '../permissions/permission.module';
 import { UserModule } from '../users/user.module';
 
@@ -16,7 +16,7 @@ import { UserModule } from '../users/user.module';
     forwardRef(() => SetupModule),
     PermissionModule,
     forwardRef(() => UserModule),
-    HistoryModule,
+    AuditModule,
   ],
 
   providers: [

--- a/src/modules/rooms/room.module.ts
+++ b/src/modules/rooms/room.module.ts
@@ -5,8 +5,7 @@ import { Room } from './domain/entities/room.entity';
 import { RoomTypeormRepository } from './infrastructure/repositories/room.typeorm.repository';
 import { RoomUseCases } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
-import { PermissionModule } from '../permissions/permission.module';
-import { UserModule } from '../users/user.module';
+import { HistoryModule } from '../history/history.module';
 
 @Module({
   controllers: [RoomController],
@@ -15,6 +14,7 @@ import { UserModule } from '../users/user.module';
     forwardRef(() => SetupModule),
     PermissionModule,
     forwardRef(() => UserModule),
+    HistoryModule
   ],
   providers: [
     ...RoomUseCases,

--- a/src/modules/servers/application/use-cases/create-server.use-case.ts
+++ b/src/modules/servers/application/use-cases/create-server.use-case.ts
@@ -69,7 +69,7 @@ export class CreateServerUseCase {
 
     const entity = this.serverDomain.createServerEntityFromDto(dto, ilo.id);
     const server = await this.serverRepository.save(entity);
-    await this.logHistory?.execute('server', server.id, 'CREATE');
+    await this.logHistory?.execute('server', server.id, 'CREATE', userId);
 
     const user = await this.userRepository.findOneByField({
       field: 'id',

--- a/src/modules/servers/application/use-cases/create-server.use-case.ts
+++ b/src/modules/servers/application/use-cases/create-server.use-case.ts
@@ -15,6 +15,7 @@ import { GroupServerRepositoryInterface } from '@/modules/groups/domain/interfac
 import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
 import { PermissionBit } from '@/modules/permissions/domain/value-objects/permission-bit.enum';
 import { PermissionServerRepositoryInterface } from '@/modules/permissions/infrastructure/interfaces/permission.server.repository.interface';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 import { UpsRepositoryInterface } from '@/modules/ups/domain/interfaces/ups.repository.interface';
 
 @Injectable()
@@ -34,6 +35,7 @@ export class CreateServerUseCase {
     private readonly userRepository: UserRepositoryInterface,
     @Inject('PermissionServerRepositoryInterface')
     private readonly permissionRepository: PermissionServerRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(
@@ -67,6 +69,7 @@ export class CreateServerUseCase {
 
     const entity = this.serverDomain.createServerEntityFromDto(dto, ilo.id);
     const server = await this.serverRepository.save(entity);
+    await this.logHistory?.execute('server', server.id, 'CREATE');
 
     const user = await this.userRepository.findOneByField({
       field: 'id',

--- a/src/modules/servers/application/use-cases/delete-server.use-case.ts
+++ b/src/modules/servers/application/use-cases/delete-server.use-case.ts
@@ -13,9 +13,9 @@ export class DeleteServerUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string): Promise<void> {
+  async execute(id: string, userId?: string): Promise<void> {
     await this.serverRepository.deleteServer(id);
     await this.deleteIloUsecase.execute(id);
-    await this.logHistory?.execute('server', id, 'DELETE');
+    await this.logHistory?.execute('server', id, 'DELETE', userId);
   }
 }

--- a/src/modules/servers/application/use-cases/delete-server.use-case.ts
+++ b/src/modules/servers/application/use-cases/delete-server.use-case.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ServerRepositoryInterface } from '@/modules/servers/domain/interfaces/server.repository.interface';
 
 import { DeleteIloUseCase } from '@/modules/ilos/application/use-cases';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class DeleteServerUseCase {
@@ -9,10 +10,12 @@ export class DeleteServerUseCase {
     @Inject('ServerRepositoryInterface')
     private readonly serverRepository: ServerRepositoryInterface,
     private readonly deleteIloUsecase: DeleteIloUseCase,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
     await this.serverRepository.deleteServer(id);
     await this.deleteIloUsecase.execute(id);
+    await this.logHistory?.execute('server', id, 'DELETE');
   }
 }

--- a/src/modules/servers/application/use-cases/update-server.use-case.ts
+++ b/src/modules/servers/application/use-cases/update-server.use-case.ts
@@ -17,11 +17,15 @@ export class UpdateServerUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string, dto: ServerUpdateDto): Promise<ServerResponseDto> {
+  async execute(
+    id: string,
+    dto: ServerUpdateDto,
+    userId?: string,
+  ): Promise<ServerResponseDto> {
     const existing = await this.serverRepository.findServerById(id);
     const entity = this.serverDomain.updateServerEntityFromDto(existing, dto);
     const updated = await this.serverRepository.save(entity);
-    await this.logHistory?.execute('server', updated.id, 'UPDATE');
+    await this.logHistory?.execute('server', updated.id, 'UPDATE', userId);
 
     const ilo = dto.ilo
       ? await this.updateIloUsecase.execute(id, dto.ilo)

--- a/src/modules/servers/server.module.ts
+++ b/src/modules/servers/server.module.ts
@@ -10,6 +10,7 @@ import { PermissionModule } from '../permissions/permission.module';
 import { UserModule } from '../users/user.module';
 import { RoomModule } from '../rooms/room.module';
 import { GroupModule } from '../groups/group.module';
+import { HistoryModule } from '../history/history.module';
 import { UpsModule } from '../ups/ups.module';
 
 @Module({
@@ -24,6 +25,7 @@ import { UpsModule } from '../ups/ups.module';
     forwardRef(() => UpsModule),
     GroupModule,
     PermissionModule,
+    HistoryModule,
   ],
   providers: [
     ...ServerUseCases,

--- a/src/modules/servers/server.module.ts
+++ b/src/modules/servers/server.module.ts
@@ -10,7 +10,7 @@ import { PermissionModule } from '../permissions/permission.module';
 import { UserModule } from '../users/user.module';
 import { RoomModule } from '../rooms/room.module';
 import { GroupModule } from '../groups/group.module';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 import { UpsModule } from '../ups/ups.module';
 
 @Module({
@@ -25,7 +25,7 @@ import { UpsModule } from '../ups/ups.module';
     forwardRef(() => UpsModule),
     GroupModule,
     PermissionModule,
-    HistoryModule,
+    AuditModule,
   ],
   providers: [
     ...ServerUseCases,

--- a/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
+++ b/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
@@ -120,7 +120,11 @@ describe('UpsController', () => {
     updateUseCase.execute.mockResolvedValue(mock);
     const result = await controller.updateUps('ups-123', dto, mockPayload);
     expect(result).toEqual(mock);
-    expect(updateUseCase.execute).toHaveBeenCalledWith('ups-123', dto);
+    expect(updateUseCase.execute).toHaveBeenCalledWith(
+      'ups-123',
+      dto,
+      mockPayload.userId,
+    );
   });
 
   it('should propagate error on updateUps', async () => {
@@ -133,7 +137,10 @@ describe('UpsController', () => {
   it('should delete a UPS', async () => {
     deleteUseCase.execute.mockResolvedValue();
     await controller.deleteUps('ups-123', mockPayload);
-    expect(deleteUseCase.execute).toHaveBeenCalledWith('ups-123');
+    expect(deleteUseCase.execute).toHaveBeenCalledWith(
+      'ups-123',
+      mockPayload.userId,
+    );
   });
 
   it('should propagate error on deleteUps', async () => {

--- a/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
+++ b/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
@@ -11,6 +11,7 @@ import {
   createMockUpsDto,
 } from '@/modules/ups/__mocks__/ups.mock';
 import { UpsResponseDto } from '../../dto/ups.response.dto';
+import { JwtPayload } from '@/core/types/jwt-payload.interface';
 
 describe('UpsController', () => {
   let controller: UpsController;
@@ -20,6 +21,11 @@ describe('UpsController', () => {
   let createUseCase: jest.Mocked<CreateUpsUseCase>;
   let updateUseCase: jest.Mocked<UpdateUpsUseCase>;
   let deleteUseCase: jest.Mocked<DeleteUpsUseCase>;
+
+  const mockPayload: JwtPayload = {
+    userId: 'user-123',
+    email: 'john.doe@example.com',
+  };
 
   beforeEach(async () => {
     getAllUseCase = { execute: jest.fn() } as any;
@@ -95,22 +101,24 @@ describe('UpsController', () => {
     const dto = createMockUpsDto();
     const mock = new UpsResponseDto({ ...dto, id: 'ups-123' } as any);
     createUseCase.execute.mockResolvedValue(mock);
-    const result = await controller.createUps(dto);
+    const result = await controller.createUps(dto, mockPayload);
     expect(result).toEqual(mock);
-    expect(createUseCase.execute).toHaveBeenCalledWith(dto);
+    expect(createUseCase.execute).toHaveBeenCalledWith(dto, mockPayload.userId);
   });
 
   it('should propagate error on createUps', async () => {
     const dto = createMockUpsDto();
     createUseCase.execute.mockRejectedValue(new Error('fail'));
-    await expect(controller.createUps(dto)).rejects.toThrow('fail');
+    await expect(controller.createUps(dto, mockPayload)).rejects.toThrow(
+      'fail',
+    );
   });
 
   it('should update a UPS', async () => {
     const dto = { name: 'Updated UPS' };
     const mock = new UpsResponseDto(createMockUps({ name: 'Updated UPS' }));
     updateUseCase.execute.mockResolvedValue(mock);
-    const result = await controller.updateUps('ups-123', dto);
+    const result = await controller.updateUps('ups-123', dto, mockPayload);
     expect(result).toEqual(mock);
     expect(updateUseCase.execute).toHaveBeenCalledWith('ups-123', dto);
   });
@@ -118,18 +126,20 @@ describe('UpsController', () => {
   it('should propagate error on updateUps', async () => {
     updateUseCase.execute.mockRejectedValue(new Error('fail'));
     await expect(
-      controller.updateUps('ups-123', { name: 'fail' }),
+      controller.updateUps('ups-123', { name: 'fail' }, mockPayload),
     ).rejects.toThrow('fail');
   });
 
   it('should delete a UPS', async () => {
     deleteUseCase.execute.mockResolvedValue();
-    await controller.deleteUps('ups-123');
+    await controller.deleteUps('ups-123', mockPayload);
     expect(deleteUseCase.execute).toHaveBeenCalledWith('ups-123');
   });
 
   it('should propagate error on deleteUps', async () => {
     deleteUseCase.execute.mockRejectedValue(new Error('fail'));
-    await expect(controller.deleteUps('ups-123')).rejects.toThrow('fail');
+    await expect(controller.deleteUps('ups-123', mockPayload)).rejects.toThrow(
+      'fail',
+    );
   });
 });

--- a/src/modules/ups/application/use-cases/create-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/create-ups.use-case.ts
@@ -14,13 +14,13 @@ export class CreateUpsUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(dto: UpsCreationDto): Promise<UpsResponseDto> {
+  async execute(dto: UpsCreationDto, userId?: string): Promise<UpsResponseDto> {
     const entity =
       await this.upsDomainService.createUpsEntityFromCreateDto(dto);
     const saved = await this.upsRepository.save(entity);
 
     const ups = Array.isArray(saved) ? saved[0] : saved;
-    await this.logHistory?.execute('ups', ups.id, 'CREATE');
+    await this.logHistory?.execute('ups', ups.id, 'CREATE', userId);
     return new UpsResponseDto(ups);
   }
 }

--- a/src/modules/ups/application/use-cases/create-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/create-ups.use-case.ts
@@ -3,6 +3,7 @@ import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.i
 import { UpsCreationDto } from '../../application/dto/ups.creation.dto';
 import { UpsResponseDto } from '../../application/dto/ups.response.dto';
 import { UpsDomainService } from '../../domain/services/ups.domain.service';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class CreateUpsUseCase {
@@ -10,6 +11,7 @@ export class CreateUpsUseCase {
     @Inject('UpsRepositoryInterface')
     private readonly upsRepository: UpsRepositoryInterface,
     private readonly upsDomainService: UpsDomainService,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(dto: UpsCreationDto): Promise<UpsResponseDto> {
@@ -18,7 +20,7 @@ export class CreateUpsUseCase {
     const saved = await this.upsRepository.save(entity);
 
     const ups = Array.isArray(saved) ? saved[0] : saved;
-
+    await this.logHistory?.execute('ups', ups.id, 'CREATE');
     return new UpsResponseDto(ups);
   }
 }

--- a/src/modules/ups/application/use-cases/delete-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/delete-ups.use-case.ts
@@ -1,15 +1,18 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.interface';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class DeleteUpsUseCase {
   constructor(
     @Inject('UpsRepositoryInterface')
     private readonly upsRepository: UpsRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
     await this.upsRepository.findUpsById(id);
     await this.upsRepository.deleteUps(id);
+    await this.logHistory?.execute('ups', id, 'DELETE');
   }
 }

--- a/src/modules/ups/application/use-cases/delete-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/delete-ups.use-case.ts
@@ -10,9 +10,9 @@ export class DeleteUpsUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string): Promise<void> {
+  async execute(id: string, userId?: string): Promise<void> {
     await this.upsRepository.findUpsById(id);
     await this.upsRepository.deleteUps(id);
-    await this.logHistory?.execute('ups', id, 'DELETE');
+    await this.logHistory?.execute('ups', id, 'DELETE', userId);
   }
 }

--- a/src/modules/ups/application/use-cases/update-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/update-ups.use-case.ts
@@ -14,13 +14,17 @@ export class UpdateUpsUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string, dto: UpsUpdateDto): Promise<UpsResponseDto> {
+  async execute(
+    id: string,
+    dto: UpsUpdateDto,
+    userId?: string,
+  ): Promise<UpsResponseDto> {
     let ups = await this.upsRepository.findUpsById(id);
 
     ups = await this.upsDomainService.createUpsEntityFromUpdateDto(ups, dto);
     const saved = await this.upsRepository.save(ups);
     ups = Array.isArray(saved) ? saved[0] : saved;
-    await this.logHistory?.execute('ups', ups.id, 'UPDATE');
+    await this.logHistory?.execute('ups', ups.id, 'UPDATE', userId);
     return new UpsResponseDto(ups);
   }
 }

--- a/src/modules/ups/application/use-cases/update-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/update-ups.use-case.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.interface';
 import { UpsUpdateDto } from '../../application/dto/ups.update.dto';
 import { UpsResponseDto } from '../../application/dto/ups.response.dto';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class UpdateUpsUseCase {
@@ -10,6 +11,7 @@ export class UpdateUpsUseCase {
     @Inject('UpsRepositoryInterface')
     private readonly upsRepository: UpsRepositoryInterface,
     private readonly upsDomainService: UpsDomainService,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string, dto: UpsUpdateDto): Promise<UpsResponseDto> {
@@ -18,7 +20,7 @@ export class UpdateUpsUseCase {
     ups = await this.upsDomainService.createUpsEntityFromUpdateDto(ups, dto);
     const saved = await this.upsRepository.save(ups);
     ups = Array.isArray(saved) ? saved[0] : saved;
-
+    await this.logHistory?.execute('ups', ups.id, 'UPDATE');
     return new UpsResponseDto(ups);
   }
 }

--- a/src/modules/ups/ups.module.ts
+++ b/src/modules/ups/ups.module.ts
@@ -5,11 +5,12 @@ import { Ups } from './domain/entities/ups.entity';
 import { UpsTypeormRepository } from './infrastructure/repositories/ups.typeorm.repository';
 import { UpsUseCases } from './application/use-cases';
 import { UpsDomainService } from './domain/services/ups.domain.service';
+import { HistoryModule } from '../history/history.module';
 
 @Module({
   controllers: [UpsController],
   exports: [...UpsUseCases, 'UpsRepositoryInterface'],
-  imports: [TypeOrmModule.forFeature([Ups])],
+  imports: [TypeOrmModule.forFeature([Ups]), HistoryModule],
   providers: [
     ...UpsUseCases,
     UpsDomainService,

--- a/src/modules/ups/ups.module.ts
+++ b/src/modules/ups/ups.module.ts
@@ -5,12 +5,12 @@ import { Ups } from './domain/entities/ups.entity';
 import { UpsTypeormRepository } from './infrastructure/repositories/ups.typeorm.repository';
 import { UpsUseCases } from './application/use-cases';
 import { UpsDomainService } from './domain/services/ups.domain.service';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   controllers: [UpsController],
   exports: [...UpsUseCases, 'UpsRepositoryInterface'],
-  imports: [TypeOrmModule.forFeature([Ups]), HistoryModule],
+  imports: [TypeOrmModule.forFeature([Ups]), AuditModule],
   providers: [
     ...UpsUseCases,
     UpsDomainService,

--- a/src/modules/users/application/use-cases/delete-user.use-case.ts
+++ b/src/modules/users/application/use-cases/delete-user.use-case.ts
@@ -10,12 +10,12 @@ export class DeleteUserUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string): Promise<void> {
+  async execute(id: string, userId?: string): Promise<void> {
     await this.repo.findOneByField({
       field: 'id',
       value: id,
     });
     await this.repo.deleteUser(id);
-    await this.logHistory?.execute('user', id, 'DELETE');
+    await this.logHistory?.execute('user', id, 'DELETE', userId);
   }
 }

--- a/src/modules/users/application/use-cases/delete-user.use-case.ts
+++ b/src/modules/users/application/use-cases/delete-user.use-case.ts
@@ -1,4 +1,5 @@
 import { Inject } from '@nestjs/common';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 import { UserRepositoryInterface } from '../../domain/interfaces/user.repository.interface';
 
@@ -6,6 +7,7 @@ export class DeleteUserUseCase {
   constructor(
     @Inject('UserRepositoryInterface')
     private readonly repo: UserRepositoryInterface,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string): Promise<void> {
@@ -14,5 +16,6 @@ export class DeleteUserUseCase {
       value: id,
     });
     await this.repo.deleteUser(id);
+    await this.logHistory?.execute('user', id, 'DELETE');
   }
 }

--- a/src/modules/users/application/use-cases/register-user.use-case.ts
+++ b/src/modules/users/application/use-cases/register-user.use-case.ts
@@ -16,7 +16,7 @@ export class RegisterUserUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(dto: RegisterDto): Promise<User> {
+  async execute(dto: RegisterDto, userId?: string): Promise<User> {
     const usernameExists = await this.repo.findOneByField({
       field: 'username',
       value: dto.username,
@@ -42,7 +42,7 @@ export class RegisterUserUseCase {
       dto.lastName,
     );
     const saved = await this.repo.save(user);
-    await this.logHistory?.execute('user', saved.id, 'CREATE');
+    await this.logHistory?.execute('user', saved.id, 'CREATE', userId);
     return saved;
   }
 }

--- a/src/modules/users/application/use-cases/register-user.use-case.ts
+++ b/src/modules/users/application/use-cases/register-user.use-case.ts
@@ -16,7 +16,7 @@ export class RegisterUserUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(dto: RegisterDto, userId?: string): Promise<User> {
+  async execute(dto: RegisterDto): Promise<User> {
     const usernameExists = await this.repo.findOneByField({
       field: 'username',
       value: dto.username,
@@ -42,7 +42,7 @@ export class RegisterUserUseCase {
       dto.lastName,
     );
     const saved = await this.repo.save(user);
-    await this.logHistory?.execute('user', saved.id, 'CREATE', userId);
+    await this.logHistory?.execute('user', saved.id, 'CREATE', saved.id);
     return saved;
   }
 }

--- a/src/modules/users/application/use-cases/register-user.use-case.ts
+++ b/src/modules/users/application/use-cases/register-user.use-case.ts
@@ -5,6 +5,7 @@ import { EnsureDefaultRoleUseCase } from '@/modules/roles/application/use-cases'
 import { RegisterDto } from '@/modules/auth/application/dto/register.dto';
 import { User } from '../../domain/entities/user.entity';
 import { UserConflictException } from '../../domain/exceptions/user.exception';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 export class RegisterUserUseCase {
   constructor(
@@ -12,6 +13,7 @@ export class RegisterUserUseCase {
     private readonly repo: UserRepositoryInterface,
     private readonly domain: UserDomainService,
     private readonly ensureDefaultRoleUseCase: EnsureDefaultRoleUseCase,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(dto: RegisterDto): Promise<User> {
@@ -39,6 +41,8 @@ export class RegisterUserUseCase {
       dto.firstName,
       dto.lastName,
     );
-    return await this.repo.save(user);
+    const saved = await this.repo.save(user);
+    await this.logHistory?.execute('user', saved.id, 'CREATE');
+    return saved;
   }
 }

--- a/src/modules/users/application/use-cases/update-user.use-case.ts
+++ b/src/modules/users/application/use-cases/update-user.use-case.ts
@@ -14,7 +14,11 @@ export class UpdateUserUseCase {
     private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
-  async execute(id: string, dto: UserUpdateDto): Promise<UserResponseDto> {
+  async execute(
+    id: string,
+    dto: UserUpdateDto,
+    userId?: string,
+  ): Promise<UserResponseDto> {
     let user = await this.repo.findOneByField({
       field: 'id',
       value: id,
@@ -24,7 +28,7 @@ export class UpdateUserUseCase {
     await this.userDomainService.ensureUniqueUsername(dto.username, id);
     user = await this.userDomainService.updateUserEntity(user, dto);
     user = await this.repo.save(user);
-    await this.logHistory?.execute('user', user.id, 'UPDATE');
+    await this.logHistory?.execute('user', user.id, 'UPDATE', userId);
     return new UserResponseDto(user);
   }
 }

--- a/src/modules/users/application/use-cases/update-user.use-case.ts
+++ b/src/modules/users/application/use-cases/update-user.use-case.ts
@@ -3,6 +3,7 @@ import { UserRepositoryInterface } from '../../domain/interfaces/user.repository
 import { UserResponseDto } from '../dto/user.response.dto';
 import { UserUpdateDto } from '../dto/user.update.dto';
 import { UserDomainService } from '../../domain/services/user.domain.service';
+import { LogHistoryUseCase } from '@/modules/history/application/use-cases';
 
 @Injectable()
 export class UpdateUserUseCase {
@@ -10,6 +11,7 @@ export class UpdateUserUseCase {
     @Inject('UserRepositoryInterface')
     private readonly repo: UserRepositoryInterface,
     private readonly userDomainService: UserDomainService,
+    private readonly logHistory?: LogHistoryUseCase,
   ) {}
 
   async execute(id: string, dto: UserUpdateDto): Promise<UserResponseDto> {
@@ -22,6 +24,7 @@ export class UpdateUserUseCase {
     await this.userDomainService.ensureUniqueUsername(dto.username, id);
     user = await this.userDomainService.updateUserEntity(user, dto);
     user = await this.repo.save(user);
+    await this.logHistory?.execute('user', user.id, 'UPDATE');
     return new UserResponseDto(user);
   }
 }

--- a/src/modules/users/user.module.ts
+++ b/src/modules/users/user.module.ts
@@ -7,6 +7,7 @@ import { UserDomainService } from './domain/services/user.domain.service';
 import { RoleModule } from '../roles/role.module';
 import { UserUseCase } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
+import { HistoryModule } from '../history/history.module';
 
 @Module({
   controllers: [UserController],
@@ -15,6 +16,7 @@ import { SetupModule } from '../setup/setup.module';
     TypeOrmModule.forFeature([User]),
     forwardRef(() => RoleModule),
     forwardRef(() => SetupModule),
+    HistoryModule,
   ],
   providers: [
     ...UserUseCase,

--- a/src/modules/users/user.module.ts
+++ b/src/modules/users/user.module.ts
@@ -7,7 +7,7 @@ import { UserDomainService } from './domain/services/user.domain.service';
 import { RoleModule } from '../roles/role.module';
 import { UserUseCase } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   controllers: [UserController],
@@ -16,7 +16,7 @@ import { HistoryModule } from '../history/history.module';
     TypeOrmModule.forFeature([User]),
     forwardRef(() => RoleModule),
     forwardRef(() => SetupModule),
-    HistoryModule,
+    AuditModule,
   ],
   providers: [
     ...UserUseCase,


### PR DESCRIPTION
# Summary
add History module with HistoryEvent entity to store creation events
log create/update/delete operations for users, servers, rooms and UPS
expose optional dashboard endpoint to query creation stats
wire History module into main app