### PR TITLE
feat/history: add filters to history list

### DIFF
--- a/src/modules/history/application/controllers/__tests__/history.controller.spec.ts
+++ b/src/modules/history/application/controllers/__tests__/history.controller.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HistoryController } from '../history.controller';
 import { GetHistoryListUseCase } from '../../use-cases/get-history-list.use-case';
+import { RoleGuard } from '@/core/guards/role.guard';
+import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
+import { Reflector } from '@nestjs/core';
+import { GetUserWithRoleUseCase } from '@/modules/users/application/use-cases/get-user-with-role.use-case';
 
 describe('HistoryController', () => {
   let controller: HistoryController;
@@ -9,10 +13,29 @@ describe('HistoryController', () => {
   beforeEach(async () => {
     getList = { execute: jest.fn() } as any;
 
+    const mockRoleGuard = { canActivate: jest.fn().mockReturnValue(true) };
+    const mockJwtAuthGuard = { canActivate: jest.fn().mockReturnValue(true) };
+    const mockGetUserWithRoleUseCase = { execute: jest.fn() };
+    const mockReflector = {
+      get: jest.fn(),
+      getAll: jest.fn(),
+      getAllAndMerge: jest.fn(),
+      getAllAndOverride: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HistoryController],
-      providers: [{ provide: GetHistoryListUseCase, useValue: getList }],
-    }).compile();
+      providers: [
+        { provide: GetHistoryListUseCase, useValue: getList },
+        { provide: GetUserWithRoleUseCase, useValue: mockGetUserWithRoleUseCase },
+        { provide: Reflector, useValue: mockReflector },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
+      .overrideGuard(RoleGuard)
+      .useValue(mockRoleGuard)
+      .compile();
 
     controller = module.get(HistoryController);
   });
@@ -20,8 +43,14 @@ describe('HistoryController', () => {
   it('returns paginated history', async () => {
     const mock = { items: [] } as any;
     getList.execute.mockResolvedValue(mock);
-    const result = await controller.getHistory('2', '5');
-    expect(getList.execute).toHaveBeenCalledWith(2, 5);
+    const result = await controller.getHistory('2', '5', 'CREATE');
+    expect(getList.execute).toHaveBeenCalledWith(2, 5, {
+      action: 'CREATE',
+      entity: undefined,
+      userId: undefined,
+      from: undefined,
+      to: undefined,
+    });
     expect(result).toBe(mock);
   });
 
@@ -29,7 +58,13 @@ describe('HistoryController', () => {
     const mock = { items: [] } as any;
     getList.execute.mockResolvedValue(mock);
     const result = await controller.getHistory();
-    expect(getList.execute).toHaveBeenCalledWith(1, 10);
+    expect(getList.execute).toHaveBeenCalledWith(1, 10, {
+      action: undefined,
+      entity: undefined,
+      userId: undefined,
+      from: undefined,
+      to: undefined,
+    });
     expect(result).toBe(mock);
   });
 });

--- a/src/modules/history/application/controllers/history.controller.ts
+++ b/src/modules/history/application/controllers/history.controller.ts
@@ -19,6 +19,11 @@ export class HistoryController {
   @Get()
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'action', required: false, type: String })
+  @ApiQuery({ name: 'entity', required: false, type: String })
+  @ApiQuery({ name: 'userId', required: false, type: String })
+  @ApiQuery({ name: 'from', required: false, type: String })
+  @ApiQuery({ name: 'to', required: false, type: String })
   @UseGuards(JwtAuthGuard, RoleGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Get paginated history events' })
@@ -26,7 +31,18 @@ export class HistoryController {
   async getHistory(
     @Query('page') page = '1',
     @Query('limit') limit = '10',
+    @Query('action') action?: string,
+    @Query('entity') entity?: string,
+    @Query('userId') userId?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
   ): Promise<HistoryListResponseDto> {
-    return this.getList.execute(Number(page), Number(limit));
+    return this.getList.execute(Number(page), Number(limit), {
+      action,
+      entity,
+      userId,
+      from,
+      to,
+    });
   }
 }

--- a/src/modules/history/application/use-cases/__tests__/get-history-list.use-case.spec.ts
+++ b/src/modules/history/application/use-cases/__tests__/get-history-list.use-case.spec.ts
@@ -17,9 +17,9 @@ describe('GetHistoryListUseCase', () => {
     const events = [new HistoryEvent()];
     repo.paginate.mockResolvedValue([events, 1]);
 
-    const result = await useCase.execute(2, 5);
+    const result = await useCase.execute(2, 5, { action: 'CREATE' });
 
-    expect(repo.paginate).toHaveBeenCalledWith(2, 5, ['user']);
+    expect(repo.paginate).toHaveBeenCalledWith(2, 5, ['user'], { action: 'CREATE' });
     expect(result.totalItems).toBe(1);
     expect(result.currentPage).toBe(2);
   });
@@ -28,7 +28,7 @@ describe('GetHistoryListUseCase', () => {
     repo.paginate.mockResolvedValue([[], 0]);
 
     const result = await useCase.execute();
-
+    expect(repo.paginate).toHaveBeenCalledWith(1, 10, ['user'], {});
     expect(result.items).toEqual([]);
     expect(result.totalItems).toBe(0);
   });

--- a/src/modules/history/application/use-cases/get-history-list.use-case.ts
+++ b/src/modules/history/application/use-cases/get-history-list.use-case.ts
@@ -1,5 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { HistoryRepositoryInterface } from '../../domain/interfaces/history.repository.interface';
+import {
+  HistoryQuery,
+  HistoryRepositoryInterface,
+} from '../../domain/interfaces/history.repository.interface';
 import { HistoryEventResponseDto } from '../dto/history-event.response.dto';
 import { HistoryListResponseDto } from '../dto/history.list.response.dto';
 
@@ -10,8 +13,12 @@ export class GetHistoryListUseCase {
     private readonly repo: HistoryRepositoryInterface,
   ) {}
 
-  async execute(page = 1, limit = 10): Promise<HistoryListResponseDto> {
-    const [events, total] = await this.repo.paginate(page, limit, ['user']);
+  async execute(
+    page = 1,
+    limit = 10,
+    query: HistoryQuery = {},
+  ): Promise<HistoryListResponseDto> {
+    const [events, total] = await this.repo.paginate(page, limit, ['user'], query);
     const dtos = events.map((e) => new HistoryEventResponseDto(e));
     return new HistoryListResponseDto(dtos, total, page, limit);
   }

--- a/src/modules/history/domain/interfaces/history.repository.interface.ts
+++ b/src/modules/history/domain/interfaces/history.repository.interface.ts
@@ -1,6 +1,14 @@
 import { GenericRepositoryInterface } from '@/core/types/generic-repository.interface';
 import { HistoryEvent } from '../entities/history-event.entity';
 
+export interface HistoryQuery {
+  action?: string;
+  entity?: string;
+  userId?: string;
+  from?: string;
+  to?: string;
+}
+
 export interface HistoryRepositoryInterface
   extends GenericRepositoryInterface<HistoryEvent> {
   countCreatedByMonth(
@@ -11,5 +19,6 @@ export interface HistoryRepositoryInterface
     page: number,
     limit: number,
     relations?: string[],
+    query?: HistoryQuery,
   ): Promise<[HistoryEvent[], number]>;
 }


### PR DESCRIPTION
## Summary
- extend history events repository with filter query support
- allow querying by action, entity, user and date range
- update controller and tests

## Testing
- `pnpm test` *(fails: RoleResponseDto spec and others)*

------
https://chatgpt.com/codex/tasks/task_b_6860fcf13804832dbaa94818a7b24cf7