### PR TITLE
feat/audit: decouple history from user

### DIFF
--- a/src/core/guards.module.ts
+++ b/src/core/guards.module.ts
@@ -1,4 +1,4 @@
-import { Module, Global } from '@nestjs/common';
+import { Module, Global, forwardRef } from '@nestjs/common';
 
 import { PermissionGuard } from './guards/permission.guard';
 import { RoleGuard } from './guards/role.guard';
@@ -12,7 +12,7 @@ import { ResourcePermissionGuard } from './guards/ressource-permission.guard';
 
 @Global()
 @Module({
-  imports: [PermissionModule, UserModule],
+  imports: [PermissionModule, forwardRef(() => UserModule)],
   providers: [
     PermissionGuard,
     RoleGuard,

--- a/src/modules/audit/audit.module.ts
+++ b/src/modules/audit/audit.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HistoryEvent } from '../history/domain/entities/history-event.entity';
+import { HistoryEventTypeormRepository } from '../history/infrastructure/repositories/history-event.typeorm.repository';
+import { LogHistoryUseCase } from '../history/application/use-cases/log-history.use-case';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([HistoryEvent])],
+  providers: [
+    LogHistoryUseCase,
+    {
+      provide: 'HistoryRepositoryInterface',
+      useClass: HistoryEventTypeormRepository,
+    },
+  ],
+  exports: [LogHistoryUseCase, 'HistoryRepositoryInterface'],
+})
+export class AuditModule {}

--- a/src/modules/history/application/use-cases/__tests__/log-history.use-case.spec.ts
+++ b/src/modules/history/application/use-cases/__tests__/log-history.use-case.spec.ts
@@ -1,0 +1,30 @@
+import { LogHistoryUseCase } from '../log-history.use-case';
+import { HistoryRepositoryInterface } from '@/modules/history/domain/interfaces/history.repository.interface';
+
+describe('LogHistoryUseCase', () => {
+  let repo: jest.Mocked<HistoryRepositoryInterface>;
+  let useCase: LogHistoryUseCase;
+
+  beforeEach(() => {
+    repo = {
+      save: jest.fn(),
+    } as any;
+    useCase = new LogHistoryUseCase(repo);
+  });
+
+  it('saves event with provided data', async () => {
+    await useCase.execute('user', 'id1', 'CREATE', 'userId');
+    expect(repo.save).toHaveBeenCalled();
+    const event = repo.save.mock.calls[0][0];
+    expect(event.entity).toBe('user');
+    expect(event.entityId).toBe('id1');
+    expect(event.action).toBe('CREATE');
+    expect(event.userId).toBe('userId');
+  });
+
+  it('saves event without optional userId', async () => {
+    await useCase.execute('user', 'id1', 'CREATE');
+    const event = repo.save.mock.calls[0][0];
+    expect(event.userId).toBeUndefined();
+  });
+});

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -1,35 +1,15 @@
-import { forwardRef, Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { HistoryEvent } from './domain/entities/history-event.entity';
-import { HistoryEventTypeormRepository } from './infrastructure/repositories/history-event.typeorm.repository';
+import { Module } from '@nestjs/common';
 import {
   GetHistoryStatsUseCase,
-  LogHistoryUseCase,
   GetHistoryListUseCase,
 } from './application/use-cases';
 import { HistoryController } from './application/controllers/history.controller';
-import { UserModule } from '../users/user.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([HistoryEvent]),
-    forwardRef(() => UserModule),
-  ],
+  imports: [AuditModule],
   controllers: [HistoryController],
-  providers: [
-    LogHistoryUseCase,
-    GetHistoryStatsUseCase,
-    GetHistoryListUseCase,
-    {
-      provide: 'HistoryRepositoryInterface',
-      useClass: HistoryEventTypeormRepository,
-    },
-  ],
-  exports: [
-    LogHistoryUseCase,
-    GetHistoryStatsUseCase,
-    GetHistoryListUseCase,
-    'HistoryRepositoryInterface',
-  ],
+  providers: [GetHistoryStatsUseCase, GetHistoryListUseCase],
+  exports: [GetHistoryStatsUseCase, GetHistoryListUseCase],
 })
 export class HistoryModule {}

--- a/src/modules/history/history.module.ts
+++ b/src/modules/history/history.module.ts
@@ -1,13 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import {
   GetHistoryStatsUseCase,
   GetHistoryListUseCase,
 } from './application/use-cases';
 import { HistoryController } from './application/controllers/history.controller';
 import { AuditModule } from '../audit/audit.module';
+import { UserModule } from '../users/user.module';
 
 @Module({
-  imports: [AuditModule],
+  imports: [AuditModule, forwardRef(() => UserModule)],
   controllers: [HistoryController],
   providers: [GetHistoryStatsUseCase, GetHistoryListUseCase],
   exports: [GetHistoryStatsUseCase, GetHistoryListUseCase],

--- a/src/modules/rooms/room.module.ts
+++ b/src/modules/rooms/room.module.ts
@@ -5,7 +5,7 @@ import { Room } from './domain/entities/room.entity';
 import { RoomTypeormRepository } from './infrastructure/repositories/room.typeorm.repository';
 import { RoomUseCases } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 import { PermissionModule } from '../permissions/permission.module';
 import { UserModule } from '../users/user.module';
 
@@ -16,7 +16,7 @@ import { UserModule } from '../users/user.module';
     forwardRef(() => SetupModule),
     PermissionModule,
     forwardRef(() => UserModule),
-    HistoryModule,
+    AuditModule,
   ],
 
   providers: [

--- a/src/modules/servers/server.module.ts
+++ b/src/modules/servers/server.module.ts
@@ -10,7 +10,7 @@ import { PermissionModule } from '../permissions/permission.module';
 import { UserModule } from '../users/user.module';
 import { RoomModule } from '../rooms/room.module';
 import { GroupModule } from '../groups/group.module';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 import { UpsModule } from '../ups/ups.module';
 
 @Module({
@@ -25,7 +25,7 @@ import { UpsModule } from '../ups/ups.module';
     forwardRef(() => UpsModule),
     GroupModule,
     PermissionModule,
-    HistoryModule,
+    AuditModule,
   ],
   providers: [
     ...ServerUseCases,

--- a/src/modules/ups/ups.module.ts
+++ b/src/modules/ups/ups.module.ts
@@ -5,12 +5,12 @@ import { Ups } from './domain/entities/ups.entity';
 import { UpsTypeormRepository } from './infrastructure/repositories/ups.typeorm.repository';
 import { UpsUseCases } from './application/use-cases';
 import { UpsDomainService } from './domain/services/ups.domain.service';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   controllers: [UpsController],
   exports: [...UpsUseCases, 'UpsRepositoryInterface'],
-  imports: [TypeOrmModule.forFeature([Ups]), HistoryModule],
+  imports: [TypeOrmModule.forFeature([Ups]), AuditModule],
   providers: [
     ...UpsUseCases,
     UpsDomainService,

--- a/src/modules/users/user.module.ts
+++ b/src/modules/users/user.module.ts
@@ -7,7 +7,7 @@ import { UserDomainService } from './domain/services/user.domain.service';
 import { RoleModule } from '../roles/role.module';
 import { UserUseCase } from './application/use-cases';
 import { SetupModule } from '../setup/setup.module';
-import { HistoryModule } from '../history/history.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   controllers: [UserController],
@@ -16,7 +16,7 @@ import { HistoryModule } from '../history/history.module';
     TypeOrmModule.forFeature([User]),
     forwardRef(() => RoleModule),
     forwardRef(() => SetupModule),
-    HistoryModule,
+    AuditModule,
   ],
   providers: [
     ...UserUseCase,


### PR DESCRIPTION
## Summary
- create an AuditModule exposing log capabilities
- refactor HistoryModule to use AuditModule and drop circular dependency
- replace HistoryModule imports with AuditModule in feature modules
- add tests for LogHistoryUseCase