### PR TITLE
docs/c4: adds C4 architecture documentation

### DIFF
--- a/docs/c4/1-system-context.md
+++ b/docs/c4/1-system-context.md
@@ -1,5 +1,7 @@
 # 🏗️ Diagramme C4 - Contexte Système
 
+1-System Context/[2-Container](./2-container.md)/[3-Components](./3-components.md)/[4-Code](./4-code.md)
+
 Cette vue décrit l'API **Infra Control** dans son environnement global.
 
 ```mermaid

--- a/docs/c4/1-system-context.md
+++ b/docs/c4/1-system-context.md
@@ -1,0 +1,26 @@
+# 🏗️ Diagramme C4 - Contexte Système
+
+Cette vue décrit l'API **Infra Control** dans son environnement global.
+
+```mermaid
+graph LR
+    subgraph Utilisateurs
+        A[Administrateurs]
+        B[Services externes]
+    end
+    subgraph "Infra Control API"
+        API
+    end
+    DB[(PostgreSQL)]
+    REDIS[(Redis)]
+
+    A-->|Requêtes HTTP|API
+    B-->|Appels API|API
+    API-->|Lecture/Écriture|DB
+    API-->|Cache|REDIS
+```
+
+Ce premier niveau met en évidence les acteurs et dépendances
+principales. Les utilisateurs (administrateurs et autres services)
+interagissent avec l'API, qui communique avec la base de données
+PostgreSQL ainsi qu'avec Redis pour la mise en cache.

--- a/docs/c4/2-container.md
+++ b/docs/c4/2-container.md
@@ -1,0 +1,26 @@
+# 🏗️ Diagramme C4 - Niveau 2 : Conteneurs
+
+Cette vue détaille les principaux conteneurs qui composent **Infra Control** et leurs interactions.
+
+```mermaid
+graph LR
+    subgraph Clients
+        A[Administrateurs]
+        B[Services externes]
+    end
+
+    subgraph "Infra Control"
+        API[NestJS API]
+    end
+    DB[(PostgreSQL)]
+    REDIS[(Redis)]
+    EXT[(Services externes)]
+
+    A-->|Requêtes REST|API
+    B-->|Appels API|API
+    API-->|Lecture/Écriture|DB
+    API-->|Cache|REDIS
+    API-->|HTTP/SSH/etc.|EXT
+```
+
+Ce diagramme montre comment l'API NestJS communique avec la base PostgreSQL, Redis pour la mise en cache ainsi que d'autres services externes.

--- a/docs/c4/2-container.md
+++ b/docs/c4/2-container.md
@@ -1,5 +1,7 @@
 # 🏗️ Diagramme C4 - Niveau 2 : Conteneurs
 
+[1-System Context](./1-system-context.md)/2-Container/[3-Components](./3-components.md)/[4-Code](./4-code.md)
+
 Cette vue détaille les principaux conteneurs qui composent **Infra Control** et leurs interactions.
 
 ```mermaid

--- a/docs/c4/3-components.md
+++ b/docs/c4/3-components.md
@@ -1,0 +1,41 @@
+# 🏗️ Diagramme C4 - Niveau 3 : Composants
+
+Cette vue zoome sur l'application NestJS et décrit quelques modules
+avec leurs contrôleurs et use cases.
+
+```mermaid
+graph LR
+    subgraph "NestJS API"
+        Auth[Auth Module]
+        Users[Users Module]
+        Servers[Servers Module]
+        Presence[Presence Module]
+    end
+    DB[(PostgreSQL)]
+    REDIS[(Redis)]
+
+    Auth --> AuthCtrl[AuthController]
+    AuthCtrl --> AuthUC[Auth Use Cases]
+
+    Users --> UsersCtrl[UsersController]
+    UsersCtrl --> UsersUC[Users Use Cases]
+
+    Servers --> ServersCtrl[ServersController]
+    ServersCtrl --> ServersUC[Servers Use Cases]
+
+    Presence --> PresenceCtrl[PresenceController]
+    PresenceCtrl --> PresenceService
+
+    AuthUC --> DB
+    UsersUC --> DB
+    ServersUC --> DB
+    PresenceService --> REDIS
+```
+
+Ce diagramme simplifie l'organisation interne : chaque contrôleur
+appelle des use cases, lesquels accèdent soit à la base de données,
+soit au cache Redis pour la présence en ligne.
+
+Le module **Presence** conserve pour chaque utilisateur connecté une clé
+`presence:<userId>` dans Redis. Le TTL de 60 secondes est réinitialisé
+régulièrement afin d'indiquer que la session est toujours active.

--- a/docs/c4/3-components.md
+++ b/docs/c4/3-components.md
@@ -1,5 +1,7 @@
 # 🏗️ Diagramme C4 - Niveau 3 : Composants
 
+[1-System Context](./1-system-context.md)/[2-Container](./2-container.md)/3-Components/[4-Code](./4-code.md)
+
 Cette vue zoome sur l'application NestJS et décrit quelques modules
 avec leurs contrôleurs et use cases.
 

--- a/docs/c4/4-code.md
+++ b/docs/c4/4-code.md
@@ -1,0 +1,24 @@
+# 🏗️ Diagramme C4 - Niveau 4 : Code
+
+[1-System Context](./1-system-context.md)/[2-Container](./2-container.md)/[3-Components](./3-components.md)/4-Code
+
+Cette vue donne un exemple de représentation détaillée du code pour un use case.
+Le diagramme ci-dessous illustre comment les classes interagissent lors de la
+création d'un utilisateur.
+
+```mermaid
+classDiagram
+    direction TB
+    class UsersController
+    class CreateUserUseCase
+    class UserTypeOrmRepository
+    class UserEntity
+
+    UsersController --> CreateUserUseCase : valide la requête
+    CreateUserUseCase --> UserTypeOrmRepository : persiste l'entité
+    UserTypeOrmRepository --> UserEntity : mapping ORM
+```
+
+Ce niveau optionnel sert à décrire plus finement les dépendances entre
+contrôleurs, use cases et services bas niveau. Il peut être développé au fur et
+à mesure des besoins.

--- a/docs/c4/README.md
+++ b/docs/c4/README.md
@@ -5,3 +5,4 @@ de l'API **Infra Control**.
 
 - [Niveau 1 — Contexte Système](./1-system-context.md)
 - [Niveau 2 — Conteneurs](./2-container.md)
+- [Niveau 3 — Composants](./3-components.md)

--- a/docs/c4/README.md
+++ b/docs/c4/README.md
@@ -6,3 +6,4 @@ de l'API **Infra Control**.
 - [Niveau 1 — Contexte Système](./1-system-context.md)
 - [Niveau 2 — Conteneurs](./2-container.md)
 - [Niveau 3 — Composants](./3-components.md)
+- [Niveau 4 — Code](./4-code.md)

--- a/docs/c4/README.md
+++ b/docs/c4/README.md
@@ -1,0 +1,6 @@
+# 📐 Diagrammes C4
+
+Cette section regroupe les schémas C4 décrivant l'architecture
+de l'API **Infra Control**.
+
+- [Niveau 1 — Contexte Système](./1-system-context.md)

--- a/docs/c4/README.md
+++ b/docs/c4/README.md
@@ -4,3 +4,4 @@ Cette section regroupe les schémas C4 décrivant l'architecture
 de l'API **Infra Control**.
 
 - [Niveau 1 — Contexte Système](./1-system-context.md)
+- [Niveau 2 — Conteneurs](./2-container.md)

--- a/docs/presence-storage.md
+++ b/docs/presence-storage.md
@@ -1,0 +1,11 @@
+# 📡 Gestion de la présence en ligne
+
+Cette page explique comment l'API enregistre l'activité des utilisateurs dans Redis afin de savoir qui est connecté.
+
+## Fonctionnement
+
+- Lorsqu'un utilisateur se connecte, le `PresenceService` crée une clé `presence:<userId>` dans Redis avec la valeur `online`.
+- La clé est associée à un TTL de 60 secondes et est renouvelée régulièrement tant que la session reste active.
+- Quand l'utilisateur se déconnecte ou que la session expire, la clé est supprimée.
+
+Ce mécanisme permet de compter rapidement les utilisateurs en ligne via la recherche des clés `presence:*`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "eslint \"src/**/*.ts\" \"test/**/*.ts\" --fix && prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "start": "pnpm format && nest start",
+    "start": "nest start",
     "dev": "ts-node-dev --respawn --transpile-only src/main.ts",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",


### PR DESCRIPTION
Implements C4 architecture diagrams to document the Infra Control API.

- Introduces C4 diagrams for system context, containers, components, and code.
- Adds documentation for presence management using Redis.