### PR TITLE
feat/releases: backend changelog endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { SetupModule } from './modules/setup/setup.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { HistoryModule } from './modules/history/history.module';
 import { SshModule } from './modules/ssh';
+import { ReleasesModule } from './modules/releases/releases.module';
 
 @Module({
   controllers: [],
@@ -43,6 +44,7 @@ import { SshModule } from './modules/ssh';
     HistoryModule,
     DashboardModule,
     SshModule,
+    ReleasesModule,
   ],
   providers: [Logger],
 })

--- a/src/modules/releases/__mocks__/release.mock.ts
+++ b/src/modules/releases/__mocks__/release.mock.ts
@@ -1,0 +1,11 @@
+import type { Release } from '../domain/interfaces/release.interface';
+
+export const createMockRelease = (overrides?: Partial<Release>): Release => ({
+  name: 'v1.0',
+  tagName: 'v1.0',
+  publishedAt: new Date().toISOString(),
+  author: 'tester',
+  body: '## Notes',
+  htmlUrl: 'https://github.com/org/repo/releases/v1.0',
+  ...overrides,
+});

--- a/src/modules/releases/application/controllers/__tests__/releases.controller.spec.ts
+++ b/src/modules/releases/application/controllers/__tests__/releases.controller.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReleasesController } from '../releases.controller';
+import { GetReleasesUseCase } from '../../use-cases/get-releases.use-case';
+import { createMockRelease } from '../../../__mocks__/release.mock';
+
+describe('ReleasesController', () => {
+  let controller: ReleasesController;
+  let useCase: GetReleasesUseCase;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReleasesController],
+      providers: [{ provide: GetReleasesUseCase, useValue: { execute: jest.fn() } }],
+    }).compile();
+
+    controller = module.get(ReleasesController);
+    useCase = module.get(GetReleasesUseCase);
+  });
+
+  it('should return changelog', async () => {
+    (useCase.execute as jest.Mock).mockResolvedValue({
+      frontend: [createMockRelease()],
+      backend: [createMockRelease()],
+    });
+
+    const result = await controller.getReleases();
+    expect(useCase.execute).toHaveBeenCalled();
+    expect(result.frontend.length).toBe(1);
+  });
+});

--- a/src/modules/releases/application/controllers/releases.controller.ts
+++ b/src/modules/releases/application/controllers/releases.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { GetReleasesUseCase } from '../use-cases/get-releases.use-case';
+
+@ApiTags('Releases')
+@Controller('releases')
+export class ReleasesController {
+  constructor(private readonly getReleasesUseCase: GetReleasesUseCase) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get project releases' })
+  async getReleases() {
+    return this.getReleasesUseCase.execute();
+  }
+}

--- a/src/modules/releases/application/use-cases/__tests__/get-releases.use-case.spec.ts
+++ b/src/modules/releases/application/use-cases/__tests__/get-releases.use-case.spec.ts
@@ -1,0 +1,27 @@
+import { GetReleasesUseCase } from '../get-releases.use-case';
+import type { GithubGatewayInterface } from '../../../domain/interfaces/github.gateway.interface';
+import { createMockRelease } from '../../../__mocks__/release.mock';
+
+describe('GetReleasesUseCase', () => {
+  let useCase: GetReleasesUseCase;
+  let gateway: jest.Mocked<GithubGatewayInterface>;
+
+  beforeEach(() => {
+    gateway = { getReleases: jest.fn() } as any;
+    useCase = new GetReleasesUseCase(gateway);
+    process.env.FRONT_REPO = 'front';
+    process.env.BACK_REPO = 'back';
+  });
+
+  it('should fetch releases for both repos', async () => {
+    gateway.getReleases.mockResolvedValueOnce([createMockRelease({ tagName: 'f' })]);
+    gateway.getReleases.mockResolvedValueOnce([createMockRelease({ tagName: 'b' })]);
+
+    const result = await useCase.execute();
+
+    expect(gateway.getReleases).toHaveBeenCalledWith('front');
+    expect(gateway.getReleases).toHaveBeenCalledWith('back');
+    expect(result.frontend[0].tagName).toBe('f');
+    expect(result.backend[0].tagName).toBe('b');
+  });
+});

--- a/src/modules/releases/application/use-cases/get-releases.use-case.ts
+++ b/src/modules/releases/application/use-cases/get-releases.use-case.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { GithubGatewayInterface } from '../../domain/interfaces/github.gateway.interface';
+import type { Release } from '../../domain/interfaces/release.interface';
+
+export interface Changelog {
+  frontend: Release[];
+  backend: Release[];
+}
+
+@Injectable()
+export class GetReleasesUseCase {
+  constructor(
+    @Inject('GithubGatewayInterface')
+    private readonly gateway: GithubGatewayInterface,
+  ) {}
+
+  async execute(): Promise<Changelog> {
+    const frontRepo = process.env.FRONT_REPO ?? '';
+    const backRepo = process.env.BACK_REPO ?? '';
+    const [frontend, backend] = await Promise.all([
+      this.gateway.getReleases(frontRepo),
+      this.gateway.getReleases(backRepo),
+    ]);
+    return { frontend, backend };
+  }
+}

--- a/src/modules/releases/application/use-cases/index.ts
+++ b/src/modules/releases/application/use-cases/index.ts
@@ -1,0 +1,1 @@
+export { GetReleasesUseCase } from './get-releases.use-case';

--- a/src/modules/releases/domain/interfaces/github.gateway.interface.ts
+++ b/src/modules/releases/domain/interfaces/github.gateway.interface.ts
@@ -1,0 +1,5 @@
+import type { Release } from './release.interface';
+
+export interface GithubGatewayInterface {
+  getReleases(repo: string): Promise<Release[]>;
+}

--- a/src/modules/releases/domain/interfaces/release.interface.ts
+++ b/src/modules/releases/domain/interfaces/release.interface.ts
@@ -1,0 +1,8 @@
+export interface Release {
+  name: string;
+  tagName: string;
+  publishedAt: string;
+  author: string | null;
+  body: string;
+  htmlUrl: string;
+}

--- a/src/modules/releases/infrastructure/github.gateway.ts
+++ b/src/modules/releases/infrastructure/github.gateway.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import type { GithubGatewayInterface } from '../domain/interfaces/github.gateway.interface';
+import type { Release } from '../domain/interfaces/release.interface';
+
+@Injectable()
+export class GithubGateway implements GithubGatewayInterface {
+  async getReleases(repo: string): Promise<Release[]> {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+    };
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+    const res = await fetch(`https://api.github.com/repos/${repo}/releases`, {
+      headers,
+    });
+    if (!res.ok) {
+      throw new Error(`GitHub error ${res.status}`);
+    }
+    const data = (await res.json()) as any[];
+    return data.map((r) => ({
+      name: r.name,
+      tagName: r.tag_name,
+      publishedAt: r.published_at,
+      author: r.author ? r.author.login : null,
+      body: r.body || '',
+      htmlUrl: r.html_url,
+    }));
+  }
+}

--- a/src/modules/releases/releases.module.ts
+++ b/src/modules/releases/releases.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ReleasesController } from './application/controllers/releases.controller';
+import { GetReleasesUseCase } from './application/use-cases/get-releases.use-case';
+import { GithubGateway } from './infrastructure/github.gateway';
+
+@Module({
+  controllers: [ReleasesController],
+  providers: [
+    GetReleasesUseCase,
+    { provide: 'GithubGatewayInterface', useClass: GithubGateway },
+  ],
+})
+export class ReleasesModule {}


### PR DESCRIPTION
## Summary
- create releases module with a GitHub gateway and use case
- expose `/releases` endpoint in `AppModule`
- add unit tests for the use case and controller
- remove placeholder frontend directory

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_6862befc044c832dbf1eb4079605782c