### PR TITLE
feat/swagger: expose json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Le script va s'occuper de lancer les containers:
 ./start_prod.sh
 ```
 
-Puis l’API est dispo sur `http://localhost:3000`  
+Puis l’API est dispo sur `http://localhost:3000`
 La doc Swagger est dispo sur `http://localhost:3000/docs`
+Le JSON du schéma est disponible sur `http://localhost:3000/docs-json`
 
 ---
 

--- a/src/core/config/swagger.config.ts
+++ b/src/core/config/swagger.config.ts
@@ -17,4 +17,8 @@ export function setupSwagger(app: INestApplication): void {
       operationsSorter: 'alpha',
     },
   });
+
+  app.use('/docs-json', (req, res) => {
+    res.status(200).json(document);
+  });
 }


### PR DESCRIPTION
## Summary
- expose JSON schema at `/docs-json`
- document Swagger JSON endpoint in README

## Testing
- `pnpm format`
- `pnpm test` *(fails: GetDashboardFullStatsUseCase marks setup as complete when complete step found)*

------
https://chatgpt.com/codex/tasks/task_b_6863a9822188832d86396b2fd1bdf39b