### PR TITLE
chore(roles): adds API responses to role endpoints

### DIFF
--- a/src/modules/roles/application/controllers/role.controller.ts
+++ b/src/modules/roles/application/controllers/role.controller.ts
@@ -17,6 +17,7 @@ import {
   ApiTags,
   ApiQuery,
   ApiBearerAuth,
+  ApiResponse,
 } from '@nestjs/swagger';
 
 import {
@@ -52,6 +53,11 @@ export class RoleController {
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   @ApiOperation({ summary: 'Récupérer la liste paginée des rôles' })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste des rôles paginée',
+    type: RoleListResponseDto,
+  })
   async getRoles(
     @Query('page') page = '1',
     @Query('limit') limit = '10',
@@ -66,6 +72,11 @@ export class RoleController {
     summary: 'Récupérer tous les rôles',
     description:
       'Renvoie la liste de tous les rôles disponibles dans le système, sans pagination.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste de tous les rôles',
+    type: [RoleResponseDto],
   })
   async getAllRoles(): Promise<RoleResponseDto[]> {
     return this.getAllRolesUseCase.execute();
@@ -83,6 +94,11 @@ export class RoleController {
     description:
       'Renvoie les informations d’un rôle spécifique identifié par son UUID.',
   })
+  @ApiResponse({
+    status: 200,
+    description: 'Détails du rôle',
+    type: RoleResponseDto,
+  })
   async getRoleById(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<RoleResponseDto> {
@@ -99,6 +115,11 @@ export class RoleController {
     summary: 'Créer un nouveau rôle',
     description:
       'Crée un rôle avec les données spécifiées dans le `RoleCreationDto`.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Rôle créé avec succès',
+    type: RoleResponseDto,
   })
   async createRole(@Body() roleDto: RoleCreationDto): Promise<RoleResponseDto> {
     return this.createRoleUseCase.execute(roleDto);
@@ -121,6 +142,11 @@ export class RoleController {
     description:
       'Met à jour un rôle existant à partir de son UUID et des nouvelles données.',
   })
+  @ApiResponse({
+    status: 200,
+    description: 'Rôle mis à jour avec succès',
+    type: RoleResponseDto,
+  })
   async updateRole(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() roleDto: RoleCreationDto,
@@ -139,6 +165,10 @@ export class RoleController {
     summary: 'Supprimer un rôle',
     description:
       'Supprime un rôle spécifique selon son UUID. Action irréversible.',
+  })
+  @ApiResponse({
+    status: 204,
+    description: 'Rôle supprimé avec succès',
   })
   async deleteRole(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return this.deleteRoleUseCase.execute(id);


### PR DESCRIPTION
Enhances API documentation by adding `@ApiResponse` decorators to each endpoint in the `RoleController`.

This provides clients with detailed information about the expected response status codes and data structures, improving API usability and clarity.
