### PR TITLE
feat/roles: add user role management endpoints

### DIFF
--- a/src/modules/roles/application/controllers/__tests__/role.controller.spec.ts
+++ b/src/modules/roles/application/controllers/__tests__/role.controller.spec.ts
@@ -7,9 +7,13 @@ import {
   GetRoleByIdUseCase,
   GetRoleListUseCase,
   UpdateRoleUseCase,
+  GetUsersByRoleUseCase,
+  UpdateUserRoleUseCase,
 } from '../../use-cases';
 import { RoleCreationDto, RoleResponseDto } from '../../dto';
 import { createMockRole } from '@/modules/roles/__mocks__/role.mock';
+import { createMockUser } from '@/modules/auth/__mocks__/user.mock';
+import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
 
 describe('RoleController', () => {
   let controller: RoleController;
@@ -19,6 +23,8 @@ describe('RoleController', () => {
   let getRoleByIdUseCase: jest.Mocked<GetRoleByIdUseCase>;
   let updateRoleUseCase: jest.Mocked<UpdateRoleUseCase>;
   let deleteRoleUseCase: jest.Mocked<DeleteRoleUseCase>;
+  let getUsersByRoleUseCase: jest.Mocked<GetUsersByRoleUseCase>;
+  let updateUserRoleUseCase: jest.Mocked<UpdateUserRoleUseCase>;
 
   beforeEach(async () => {
     createRoleUseCase = { execute: jest.fn() } as any;
@@ -27,6 +33,8 @@ describe('RoleController', () => {
     getRoleByIdUseCase = { execute: jest.fn() } as any;
     updateRoleUseCase = { execute: jest.fn() } as any;
     deleteRoleUseCase = { execute: jest.fn() } as any;
+    getUsersByRoleUseCase = { execute: jest.fn() } as any;
+    updateUserRoleUseCase = { execute: jest.fn() } as any;
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RoleController],
@@ -37,6 +45,8 @@ describe('RoleController', () => {
         { provide: GetRoleByIdUseCase, useValue: getRoleByIdUseCase },
         { provide: UpdateRoleUseCase, useValue: updateRoleUseCase },
         { provide: DeleteRoleUseCase, useValue: deleteRoleUseCase },
+        { provide: GetUsersByRoleUseCase, useValue: getUsersByRoleUseCase },
+        { provide: UpdateUserRoleUseCase, useValue: updateUserRoleUseCase },
       ],
     }).compile();
 
@@ -159,6 +169,40 @@ describe('RoleController', () => {
     it('should propagate error from usecase', async () => {
       deleteRoleUseCase.execute.mockRejectedValue(new Error('fail'));
       await expect(controller.deleteRole('uuid')).rejects.toThrow('fail');
+    });
+  });
+
+  describe('getUsersByRole', () => {
+    it('should return users of role', async () => {
+      const users = [new UserResponseDto(createMockUser({ id: 'u1' }))];
+      getUsersByRoleUseCase.execute.mockResolvedValue(users);
+
+      const result = await controller.getUsersByRole('role1');
+      expect(result).toEqual(users);
+      expect(getUsersByRoleUseCase.execute).toHaveBeenCalledWith('role1');
+    });
+
+    it('should propagate errors', async () => {
+      getUsersByRoleUseCase.execute.mockRejectedValue(new Error('fail'));
+      await expect(controller.getUsersByRole('r1')).rejects.toThrow('fail');
+    });
+  });
+
+  describe('updateUserRole', () => {
+    it('should update user role', async () => {
+      const user = new UserResponseDto(createMockUser({ id: 'u1' }));
+      updateUserRoleUseCase.execute.mockResolvedValue(user);
+
+      const result = await controller.updateUserRole('u1', 'r2');
+      expect(result).toEqual(user);
+      expect(updateUserRoleUseCase.execute).toHaveBeenCalledWith('u1', 'r2');
+    });
+
+    it('should propagate errors', async () => {
+      updateUserRoleUseCase.execute.mockRejectedValue(new Error('fail'));
+      await expect(controller.updateUserRole('u1', null)).rejects.toThrow(
+        'fail',
+      );
     });
   });
 });

--- a/src/modules/roles/application/controllers/role.controller.ts
+++ b/src/modules/roles/application/controllers/role.controller.ts
@@ -32,7 +32,10 @@ import {
   GetRoleByIdUseCase,
   GetRoleListUseCase,
   UpdateRoleUseCase,
+  GetUsersByRoleUseCase,
+  UpdateUserRoleUseCase,
 } from '@/modules/roles/application/use-cases';
+import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
 
 @ApiTags('Role')
@@ -45,6 +48,8 @@ export class RoleController {
     private readonly getRoleByIdUseCase: GetRoleByIdUseCase,
     private readonly updateRoleUseCase: UpdateRoleUseCase,
     private readonly deleteRoleUseCase: DeleteRoleUseCase,
+    private readonly getUsersByRoleUseCase: GetUsersByRoleUseCase,
+    private readonly updateUserRoleUseCase: UpdateUserRoleUseCase,
   ) {}
 
   @Get()
@@ -172,5 +177,37 @@ export class RoleController {
   })
   async deleteRole(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return this.deleteRoleUseCase.execute(id);
+  }
+
+  @Get(':id/users')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', type: String })
+  @ApiOperation({ summary: "Liste des utilisateurs d'un rôle" })
+  @ApiResponse({ status: 200, type: [UserResponseDto] })
+  async getUsersByRole(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<UserResponseDto[]> {
+    return this.getUsersByRoleUseCase.execute(id);
+  }
+
+  @Patch('user/update-account/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiParam({ name: 'id', type: String })
+  @ApiBody({
+    schema: {
+      properties: {
+        roleId: { type: 'string', format: 'uuid', nullable: true },
+      },
+    },
+  })
+  @ApiOperation({ summary: "Mettre à jour le rôle d'un utilisateur" })
+  @ApiResponse({ status: 200, type: UserResponseDto })
+  async updateUserRole(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body('roleId') roleId: string | null,
+  ): Promise<UserResponseDto> {
+    return this.updateUserRoleUseCase.execute(id, roleId);
   }
 }

--- a/src/modules/roles/application/use-cases/__tests__/get-users-by-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/get-users-by-role.use-case.spec.ts
@@ -1,0 +1,35 @@
+import { GetUsersByRoleUseCase } from '../get-users-by-role.use-case';
+import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
+import { createMockUser } from '@/modules/auth/__mocks__/user.mock';
+import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
+
+describe('GetUsersByRoleUseCase', () => {
+  let useCase: GetUsersByRoleUseCase;
+  let repo: jest.Mocked<UserRepositoryInterface>;
+
+  beforeEach(() => {
+    repo = {
+      findAllByField: jest.fn(),
+    } as any;
+    useCase = new GetUsersByRoleUseCase(repo);
+  });
+
+  it('should return users for role', async () => {
+    const user = createMockUser({ id: 'u1', roleId: 'r1' });
+    repo.findAllByField.mockResolvedValue([user]);
+
+    const result = await useCase.execute('r1');
+
+    expect(repo.findAllByField).toHaveBeenCalledWith({
+      field: 'roleId',
+      value: 'r1',
+      relations: ['role'],
+    });
+    expect(result).toEqual([new UserResponseDto(user)]);
+  });
+
+  it('should propagate errors', async () => {
+    repo.findAllByField.mockRejectedValue(new Error('fail'));
+    await expect(useCase.execute('r1')).rejects.toThrow('fail');
+  });
+});

--- a/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
@@ -1,0 +1,33 @@
+import { UpdateUserRoleUseCase } from '../update-user-role.use-case';
+import { UpdateUserFieldsUseCase } from '@/modules/users/application/use-cases';
+import { createMockUser } from '@/modules/auth/__mocks__/user.mock';
+import { User } from '@/modules/users/domain/entities/user.entity';
+import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
+
+describe('UpdateUserRoleUseCase', () => {
+  let useCase: UpdateUserRoleUseCase;
+  let updateFields: jest.Mocked<UpdateUserFieldsUseCase>;
+
+  beforeEach(() => {
+    updateFields = { execute: jest.fn() } as any;
+    useCase = new UpdateUserRoleUseCase(updateFields);
+  });
+
+  it('should update user role', async () => {
+    const user = Object.setPrototypeOf(
+      createMockUser({ id: 'u1' }),
+      User.prototype,
+    );
+    updateFields.execute.mockResolvedValue(user);
+
+    const result = await useCase.execute('u1', 'r1');
+
+    expect(updateFields.execute).toHaveBeenCalledWith('u1', { roleId: 'r1' });
+    expect(result).toEqual(new UserResponseDto(user));
+  });
+
+  it('should propagate errors', async () => {
+    updateFields.execute.mockRejectedValue(new Error('fail'));
+    await expect(useCase.execute('u1', null)).rejects.toThrow('fail');
+  });
+});

--- a/src/modules/roles/application/use-cases/get-users-by-role.use-case.ts
+++ b/src/modules/roles/application/use-cases/get-users-by-role.use-case.ts
@@ -1,0 +1,20 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
+import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
+
+@Injectable()
+export class GetUsersByRoleUseCase {
+  constructor(
+    @Inject('UserRepositoryInterface')
+    private readonly repo: UserRepositoryInterface,
+  ) {}
+
+  async execute(roleId: string): Promise<UserResponseDto[]> {
+    const users = await this.repo.findAllByField({
+      field: 'roleId',
+      value: roleId,
+      relations: ['role'],
+    });
+    return users.map((u) => new UserResponseDto(u));
+  }
+}

--- a/src/modules/roles/application/use-cases/index.ts
+++ b/src/modules/roles/application/use-cases/index.ts
@@ -5,6 +5,8 @@ import { GetAllRolesUseCase } from './get-all-roles.use-case';
 import { GetRoleByIdUseCase } from './get-role-by-id.use-case';
 import { GetRoleListUseCase } from './get-role-list.use-case';
 import { UpdateRoleUseCase } from './update-role.use-case';
+import { GetUsersByRoleUseCase } from './get-users-by-role.use-case';
+import { UpdateUserRoleUseCase } from './update-user-role.use-case';
 
 export const RoleUseCases = [
   CreateRoleUseCase,
@@ -14,6 +16,8 @@ export const RoleUseCases = [
   UpdateRoleUseCase,
   DeleteRoleUseCase,
   EnsureDefaultRoleUseCase,
+  GetUsersByRoleUseCase,
+  UpdateUserRoleUseCase,
 ];
 
 export {
@@ -24,4 +28,6 @@ export {
   UpdateRoleUseCase,
   DeleteRoleUseCase,
   EnsureDefaultRoleUseCase,
+  GetUsersByRoleUseCase,
+  UpdateUserRoleUseCase,
 };

--- a/src/modules/roles/application/use-cases/update-user-role.use-case.ts
+++ b/src/modules/roles/application/use-cases/update-user-role.use-case.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { UpdateUserFieldsUseCase } from '@/modules/users/application/use-cases';
+import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
+
+@Injectable()
+export class UpdateUserRoleUseCase {
+  constructor(private readonly updateUserFields: UpdateUserFieldsUseCase) {}
+
+  async execute(
+    userId: string,
+    roleId: string | null,
+  ): Promise<UserResponseDto> {
+    const user = await this.updateUserFields.execute(userId, { roleId });
+    return new UserResponseDto(user);
+  }
+}

--- a/src/modules/users/domain/interfaces/user.repository.interface.ts
+++ b/src/modules/users/domain/interfaces/user.repository.interface.ts
@@ -1,4 +1,8 @@
-import { FindOneByFieldOptions } from '@/core/utils/index';
+import {
+  FindOneByFieldOptions,
+  FindAllByFieldOptions,
+} from '@/core/utils/index';
+import { PrimitiveFields } from '@/core/types/primitive-fields.interface';
 import { User } from '../entities/user.entity';
 import { GenericRepositoryInterface } from '@/core/types/generic-repository.interface';
 
@@ -8,6 +12,9 @@ export interface UserRepositoryInterface
   updateFields(id: string, partialUser: Partial<User>): Promise<User>;
   count(): Promise<number>;
   save(user: User): Promise<User>;
+  findAllByField<T extends PrimitiveFields<User>>(
+    options: FindAllByFieldOptions<User, T>,
+  ): Promise<User[]>;
   updateUser(
     id: string,
     username: string,
@@ -33,4 +40,4 @@ export interface UserRepositoryInterface
     relations?: string[],
   ): Promise<[User[], number]>;
 }
-export { FindOneByFieldOptions };
+export { FindOneByFieldOptions, FindAllByFieldOptions };


### PR DESCRIPTION
## Summary
- implement new use cases to list users per role and update user role
- expose new endpoints in RoleController to manage role assignments
- extend user repository interface and implementation with `findAllByField`
- add comprehensive unit tests for controller and use cases

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6863ef20a47c832da01acf802a838122