### PR TITLE
Add thorough tests for role refactoring

### DIFF
--- a/src/modules/roles/application/controllers/__tests__/role.controller.spec.ts
+++ b/src/modules/roles/application/controllers/__tests__/role.controller.spec.ts
@@ -11,6 +11,9 @@ import {
   UpdateUserRoleUseCase,
 } from '../../use-cases';
 import { RoleCreationDto, RoleResponseDto } from '../../dto';
+import { AdminRoleCreationDto } from '../../dto/role.creation.dto';
+import { RoleUpdateDto } from '../../dto/role.update.dto';
+import { RoleGuard } from '@/core/guards';
 import { createMockRole } from '@/modules/roles/__mocks__/role.mock';
 import { createMockUser } from '@/modules/auth/__mocks__/user.mock';
 import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
@@ -48,7 +51,10 @@ describe('RoleController', () => {
         { provide: GetUsersByRoleUseCase, useValue: getUsersByRoleUseCase },
         { provide: UpdateUserRoleUseCase, useValue: updateUserRoleUseCase },
       ],
-    }).compile();
+    })
+      .overrideGuard(RoleGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .compile();
 
     controller = module.get<RoleController>(RoleController);
   });
@@ -139,9 +145,21 @@ describe('RoleController', () => {
     });
   });
 
+  describe('createAdminRole', () => {
+    it('should create admin role', async () => {
+      const dto: AdminRoleCreationDto = { name: 'ADMIN', isAdmin: true, canCreateServer: true };
+      const role = new RoleResponseDto(createMockRole({ name: 'ADMIN' }));
+      createRoleUseCase.execute.mockResolvedValue(role);
+
+      const result = await controller.createAdminRole(dto);
+      expect(result).toEqual(role);
+      expect(createRoleUseCase.execute).toHaveBeenCalledWith(dto);
+    });
+  });
+
   describe('updateRole', () => {
     it('should update a role', async () => {
-      const dto: RoleCreationDto = { name: 'UPD_ROLE' };
+      const dto: RoleUpdateDto = { name: 'UPD_ROLE' };
       const role = new RoleResponseDto(createMockRole({ name: 'UPD_ROLE' }));
       updateRoleUseCase.execute.mockResolvedValue(role);
 

--- a/src/modules/roles/application/use-cases/__tests__/create-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/create-role.use-case.spec.ts
@@ -25,26 +25,25 @@ describe('CreateRoleUseCase', () => {
 
   beforeEach(() => {
     roleRepository = {
-      createRole: jest.fn(),
+      save: jest.fn(),
     } as any;
 
     roleDomainService = {
       toRoleEntity: jest.fn(),
     } as any;
-    roleDomainService.toRoleEntity.mockImplementation((dto) =>
-      createMockRole({ name: dto.name }),
-    );
     useCase = new CreateRoleUseCase(roleRepository, roleDomainService);
   });
 
   it('should create a role and return a RoleResponseDto', async () => {
     const dto: RoleCreationDto = { name: 'ADMIN' };
     const roleEntity = createMockRole({ name: 'ADMIN' });
-    roleRepository.createRole.mockResolvedValue(roleEntity);
+    roleDomainService.toRoleEntity.mockReturnValue(roleEntity);
+    roleRepository.save.mockResolvedValue(roleEntity);
 
     const result = await useCase.execute(dto);
 
-    expect(roleRepository.createRole).toHaveBeenCalledWith('ADMIN');
+    expect(roleDomainService.toRoleEntity).toHaveBeenCalledWith(dto);
+    expect(roleRepository.save).toHaveBeenCalledWith(roleEntity);
     expect(result).toBeInstanceOf(RoleResponseDto);
     expect(result.name).toBe('ADMIN');
     expect(result.id).toBe(roleEntity.id);
@@ -53,17 +52,19 @@ describe('CreateRoleUseCase', () => {
   it('should work with another role name', async () => {
     const dto: RoleCreationDto = { name: 'GUEST' };
     const roleEntity = createMockRole({ name: 'GUEST' });
-    roleRepository.createRole.mockResolvedValue(roleEntity);
+    roleDomainService.toRoleEntity.mockReturnValue(roleEntity);
+    roleRepository.save.mockResolvedValue(roleEntity);
 
     const result = await useCase.execute(dto);
 
-    expect(roleRepository.createRole).toHaveBeenCalledWith('GUEST');
+    expect(roleDomainService.toRoleEntity).toHaveBeenCalledWith(dto);
+    expect(roleRepository.save).toHaveBeenCalledWith(roleEntity);
     expect(result.name).toBe('GUEST');
   });
 
   it('should handle repository errors', async () => {
     const dto: RoleCreationDto = { name: 'BROKEN' };
-    roleRepository.createRole.mockRejectedValue(new Error('DB Error'));
+    roleRepository.save.mockRejectedValue(new Error('DB Error'));
 
     await expect(useCase.execute(dto)).rejects.toThrow('DB Error');
   });

--- a/src/modules/roles/application/use-cases/__tests__/update-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/update-role.use-case.spec.ts
@@ -1,6 +1,6 @@
 import { createMockRole } from '@/modules/roles/__mocks__/role.mock';
 import { RoleRepositoryInterface } from '@/modules/roles/domain/interfaces/role.repository.interface';
-import { RoleCreationDto } from '../../dto/role.creation.dto';
+import { RoleUpdateDto } from '../../dto/role.update.dto';
 import { UpdateRoleUseCase } from '../update-role.use-case';
 import { RoleDomainService } from '@/modules/roles/domain/services/role.domain.service';
 
@@ -11,7 +11,8 @@ describe('UpdateRoleUseCase', () => {
 
   beforeEach(() => {
     roleRepository = {
-      updateRole: jest.fn(),
+      findOneByField: jest.fn(),
+      save: jest.fn(),
     } as any;
 
     roleDomainService = {
@@ -22,21 +23,26 @@ describe('UpdateRoleUseCase', () => {
   });
 
   it('should update and return RoleResponseDto', async () => {
-    const dto: RoleCreationDto = { name: 'NEW_NAME' };
+    const dto: RoleUpdateDto = { name: 'NEW_NAME' };
+    const entity = createMockRole({ name: 'OLD' });
     const updated = createMockRole({ name: 'NEW_NAME' });
-    roleRepository.updateRole.mockResolvedValue(updated);
+    roleRepository.findOneByField.mockResolvedValue(entity);
+    roleDomainService.updateRoleEntity.mockReturnValue(updated);
+    roleRepository.save.mockResolvedValue(updated);
 
     const result = await useCase.execute('role-id-123', dto);
 
-    expect(roleRepository.updateRole).toHaveBeenCalledWith(
-      'role-id-123',
-      'NEW_NAME',
-    );
+    expect(roleRepository.findOneByField).toHaveBeenCalledWith({
+      field: 'id',
+      value: 'role-id-123',
+    });
+    expect(roleDomainService.updateRoleEntity).toHaveBeenCalledWith(entity, dto);
+    expect(roleRepository.save).toHaveBeenCalledWith(updated);
     expect(result.name).toBe('NEW_NAME');
   });
 
   it('should throw if repository throws', async () => {
-    roleRepository.updateRole.mockRejectedValue(new Error('Failed'));
+    roleRepository.findOneByField.mockRejectedValue(new Error('Failed'));
     await expect(useCase.execute('role-id', { name: 'fail' })).rejects.toThrow(
       'Failed',
     );

--- a/src/modules/roles/domain/services/__tests__/role.domain.service.spec.ts
+++ b/src/modules/roles/domain/services/__tests__/role.domain.service.spec.ts
@@ -3,6 +3,10 @@ import {
   createMockPermissionServer,
   createMockPermissionVm,
 } from '@/modules/permissions/__mocks__/permissions.mock';
+import { RoleCreationDto } from '@/modules/roles/application/dto/role.creation.dto';
+import { AdminRoleCreationDto } from '@/modules/roles/application/dto/role.creation.dto';
+import { RoleUpdateDto } from '@/modules/roles/application/dto/role.update.dto';
+import { Role } from '../../entities/role.entity';
 
 describe('RoleDomainService', () => {
   let service: RoleDomainService;
@@ -27,5 +31,34 @@ describe('RoleDomainService', () => {
     expect(role.name).toBe('GUEST');
     expect(role.permissionServers).toContain(permServer);
     expect(role.permissionVms).toContain(permVm);
+  });
+
+  it('should convert dto to role entity', () => {
+    const dto: RoleCreationDto = { name: 'USER' };
+    const role = service.toRoleEntity(dto);
+    expect(role).toBeInstanceOf(Role);
+    expect(role.name).toBe('USER');
+  });
+
+  it('should convert admin dto to role entity with flags', () => {
+    const dto: AdminRoleCreationDto = Object.assign(new AdminRoleCreationDto(), {
+      name: 'ADMIN',
+      isAdmin: true,
+      canCreateServer: true,
+    });
+    const role = service.toRoleEntity(dto);
+    expect(role.isAdmin).toBe(true);
+    expect(role.canCreateServer).toBe(true);
+  });
+
+  it('should update a role entity', () => {
+    const role = new Role();
+    role.name = 'OLD';
+    role.isAdmin = false;
+    const dto: RoleUpdateDto = { name: 'NEW', isAdmin: true, canCreateServer: true };
+    const updated = service.updateRoleEntity(role, dto);
+    expect(updated.name).toBe('NEW');
+    expect(updated.isAdmin).toBe(true);
+    expect(updated.canCreateServer).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- adjust createRole/updateRole use case tests for new `save` logic
- cover new role domain service helpers
- mock RoleGuard in controller tests and add admin role route test

## Testing
- `pnpm test src/modules/roles`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68640199db18832d969fbf24f7fb82db