### PR TITLE
feat: transaction for user role updates

### DIFF
--- a/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
@@ -10,17 +10,20 @@ import { DataSource, EntityManager } from 'typeorm';
 
 describe('UpdateUserRoleUseCase', () => {
   let useCase: UpdateUserRoleUseCase;
-  let repo: jest.Mocked<UserRepositoryInterface>;
-  let roleRepo: jest.Mocked<RoleRepositoryInterface>;
+  let repo: any;
+  let roleRepo: any;
   let dataSource: jest.Mocked<DataSource>;
 
   beforeEach(() => {
-    repo = { findOneByField: jest.fn(), save: jest.fn() } as any;
-    roleRepo = { findOneByField: jest.fn() } as any;
+    repo = { findOneOrFail: jest.fn(), save: jest.fn() };
+    roleRepo = { findOneOrFail: jest.fn() };
     dataSource = {
       transaction: jest.fn(
         async (cb: (manager: Partial<EntityManager>) => any) =>
-          cb({ withRepository: (r: any) => r }),
+          cb({
+            getRepository: (entity: unknown) =>
+              (entity === User ? repo : roleRepo) as any,
+          }),
       ),
     } as any;
     useCase = new UpdateUserRoleUseCase(repo, roleRepo, dataSource);
@@ -31,8 +34,8 @@ describe('UpdateUserRoleUseCase', () => {
     const current = createMockUser({ id: 'u1', roles: [existingRole] });
     const newRole = createMockRole({ id: 'r1', isAdmin: false });
 
-    repo.findOneByField.mockResolvedValue(current);
-    roleRepo.findOneByField.mockResolvedValue(newRole);
+    repo.findOneOrFail.mockResolvedValue(current);
+    roleRepo.findOneOrFail.mockResolvedValue(newRole);
 
     const updated = Object.setPrototypeOf(
       { ...current, roles: [existingRole, newRole] },
@@ -42,10 +45,7 @@ describe('UpdateUserRoleUseCase', () => {
 
     const result = await useCase.execute('u1', 'r1');
 
-    expect(roleRepo.findOneByField).toHaveBeenCalledWith({
-      field: 'id',
-      value: 'r1',
-    });
+    expect(roleRepo.findOneOrFail).toHaveBeenCalledWith({ where: { id: 'r1' } });
     expect(current.roles).toEqual([existingRole, newRole]);
     expect(repo.save).toHaveBeenCalledWith(current);
     expect(dataSource.transaction).toHaveBeenCalled();
@@ -59,8 +59,8 @@ describe('UpdateUserRoleUseCase', () => {
 
     const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });
 
-    repo.findOneByField.mockResolvedValue(current);
-    roleRepo.findOneByField
+    repo.findOneOrFail.mockResolvedValue(current);
+    roleRepo.findOneOrFail
       .mockResolvedValueOnce(existingRole)
       .mockResolvedValueOnce(guestRole);
     repo.save.mockResolvedValue(updated);
@@ -80,12 +80,12 @@ describe('UpdateUserRoleUseCase', () => {
     });
     const updated = Object.setPrototypeOf(current, User.prototype);
 
-    repo.findOneByField.mockResolvedValue(current);
+    repo.findOneOrFail.mockResolvedValue(current);
     repo.save.mockResolvedValue(updated);
 
     const result = await useCase.execute('u1', null);
 
-    expect(roleRepo.findOneByField).not.toHaveBeenCalled();
+    expect(roleRepo.findOneOrFail).not.toHaveBeenCalled();
     expect(repo.save).toHaveBeenCalledWith(current);
     expect(dataSource.transaction).toHaveBeenCalled();
     expect(result).toEqual(new UserResponseDto(updated));
@@ -96,8 +96,8 @@ describe('UpdateUserRoleUseCase', () => {
     const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });
     const current = createMockUser({ id: 'u1', roles: [existingRole] });
 
-    repo.findOneByField.mockResolvedValueOnce(current); // for user
-    roleRepo.findOneByField
+    repo.findOneOrFail.mockResolvedValueOnce(current); // for user
+    roleRepo.findOneOrFail
       .mockResolvedValueOnce(existingRole) // find role to remove
       .mockResolvedValueOnce(guestRole); // find guest role
 
@@ -118,8 +118,8 @@ describe('UpdateUserRoleUseCase', () => {
     const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });
     const current = createMockUser({ id: 'u1', roles: [guestRole] });
 
-    repo.findOneByField.mockResolvedValueOnce(current); // for user
-    roleRepo.findOneByField.mockResolvedValue(guestRole); // for role
+    repo.findOneOrFail.mockResolvedValueOnce(current); // for user
+    roleRepo.findOneOrFail.mockResolvedValue(guestRole); // for role
 
     await expect(useCase.execute('u1', 'g1')).rejects.toThrow(
       CannotRemoveGuestRoleException,
@@ -128,7 +128,7 @@ describe('UpdateUserRoleUseCase', () => {
   });
 
   it('should propagate errors', async () => {
-    repo.findOneByField.mockResolvedValue(createMockUser({ roles: [] }));
+    repo.findOneOrFail.mockResolvedValue(createMockUser({ roles: [] }));
     repo.save.mockRejectedValue(new Error('fail'));
     await expect(useCase.execute('u1', null)).rejects.toThrow('fail');
     expect(dataSource.transaction).toHaveBeenCalled();

--- a/src/modules/roles/application/use-cases/update-user-role.use-case.ts
+++ b/src/modules/roles/application/use-cases/update-user-role.use-case.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
+import { User } from '@/modules/users/domain/entities/user.entity';
+import { Role } from '../../domain/entities/role.entity';
 import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
 import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
 import { RoleRepositoryInterface } from '../../domain/interfaces/role.repository.interface';
@@ -30,24 +32,16 @@ export class UpdateUserRoleUseCase {
     roleId: string | null,
   ): Promise<UserResponseDto> {
     return this.dataSource.transaction(async (manager) => {
-      const userRepo = manager.withRepository
-        ? manager.withRepository(this.repo as any)
-        : (this.repo as any);
-      const roleRepo = manager.withRepository
-        ? manager.withRepository(this.roleRepo as any)
-        : (this.roleRepo as any);
+      const userRepo = manager.getRepository(User);
+      const roleRepo = manager.getRepository(Role);
 
-      const current = await userRepo.findOneByField({
-        field: 'id',
-        value: userId,
+      const current = await userRepo.findOneOrFail({
+        where: { id: userId },
         relations: ['roles'],
       });
 
       if (roleId) {
-        const role = await roleRepo.findOneByField({
-          field: 'id',
-          value: roleId,
-        });
+        const role = await roleRepo.findOneOrFail({ where: { id: roleId } });
 
         const roleExists = current.roles?.some((r) => r.id === roleId);
         if (!roleExists) {
@@ -58,9 +52,8 @@ export class UpdateUserRoleUseCase {
           }
           current.roles = current.roles.filter((r) => r.id !== roleId);
           if (current.roles.length === 0) {
-            const guest = await roleRepo.findOneByField({
-              field: 'name',
-              value: 'GUEST',
+            const guest = await roleRepo.findOneOrFail({
+              where: { name: 'GUEST' },
             });
             current.roles = [guest];
           }


### PR DESCRIPTION
## Summary
- ensure update user role use case runs in a single transaction
- adapt user role update tests for transaction behavior