### PR TITLE
feat/admin-role-protection

### DIFF
--- a/src/core/filters/user.exception.filter.ts
+++ b/src/core/filters/user.exception.filter.ts
@@ -12,6 +12,7 @@ import {
   UserRetrievalException,
   UserUpdateException,
   CannotDeleteLastAdminException,
+  CannotRemoveLastAdminException,
 } from '@/modules/users/domain/exceptions/user.exception';
 
 @Catch(
@@ -22,6 +23,7 @@ import {
   UserRetrievalException,
   UserRegistrationException,
   CannotDeleteLastAdminException,
+  CannotRemoveLastAdminException,
 )
 export class UserExceptionFilter implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
@@ -33,7 +35,8 @@ export class UserExceptionFilter implements ExceptionFilter {
       status = HttpStatus.NOT_FOUND;
     } else if (
       exception instanceof UserConflictException ||
-      exception instanceof CannotDeleteLastAdminException
+      exception instanceof CannotDeleteLastAdminException ||
+      exception instanceof CannotRemoveLastAdminException
     ) {
       status = HttpStatus.CONFLICT;
     }

--- a/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
@@ -7,6 +7,7 @@ import { RoleRepositoryInterface } from '@/modules/roles/domain/interfaces/role.
 import { createMockRole } from '@/modules/roles/__mocks__/role.mock';
 import { CannotRemoveGuestRoleException } from '@/modules/roles/domain/exceptions/role.exception';
 import { DataSource, EntityManager } from 'typeorm';
+import { CannotRemoveLastAdminException } from '@/modules/users/domain/exceptions/user.exception';
 
 describe('UpdateUserRoleUseCase', () => {
   let useCase: UpdateUserRoleUseCase;
@@ -55,7 +56,10 @@ describe('UpdateUserRoleUseCase', () => {
   it('should not add duplicate role', async () => {
     const existingRole = createMockRole({ id: 'r1', isAdmin: true });
     const otherRole = createMockRole({ id: 'r2', isAdmin: false });
-    const current = createMockUser({ id: 'u1', roles: [existingRole, otherRole] });
+    const current = createMockUser({
+      id: 'u1',
+      roles: [existingRole, otherRole],
+    });
     const updated = Object.setPrototypeOf(current, User.prototype);
 
     const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });

--- a/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
+++ b/src/modules/roles/application/use-cases/__tests__/update-user-role.use-case.spec.ts
@@ -2,8 +2,6 @@ import { UpdateUserRoleUseCase } from '../update-user-role.use-case';
 import { createMockUser } from '@/modules/auth/__mocks__/user.mock';
 import { User } from '@/modules/users/domain/entities/user.entity';
 import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
-import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
-import { RoleRepositoryInterface } from '@/modules/roles/domain/interfaces/role.repository.interface';
 import { createMockRole } from '@/modules/roles/__mocks__/role.mock';
 import { CannotRemoveGuestRoleException } from '@/modules/roles/domain/exceptions/role.exception';
 import { DataSource, EntityManager } from 'typeorm';
@@ -16,6 +14,14 @@ describe('UpdateUserRoleUseCase', () => {
   let dataSource: jest.Mocked<DataSource>;
 
   beforeEach(() => {
+    repo = {
+      findOneOrFail: jest.fn(),
+      save: jest.fn(),
+      count: jest.fn(),
+    };
+    roleRepo = {
+      findOneOrFail: jest.fn(),
+    };
     dataSource = {
       transaction: jest.fn(
         async (cb: (manager: Partial<EntityManager>) => any) =>
@@ -33,42 +39,48 @@ describe('UpdateUserRoleUseCase', () => {
     const current = createMockUser({ id: 'u1', roles: [existingRole] });
     const newRole = createMockRole({ id: 'r1', isAdmin: false });
 
-    repo.findOneOrFail.mockResolvedValue(current);
-    roleRepo.findOneOrFail.mockResolvedValue(newRole);
+    repo.findOneOrFail.mockResolvedValueOnce(current); // user
+    roleRepo.findOneOrFail.mockResolvedValueOnce(newRole); // role
 
     const updated = Object.setPrototypeOf(
       { ...current, roles: [existingRole, newRole] },
       User.prototype,
     );
-    repo.save.mockResolvedValue(updated);
+    repo.save.mockResolvedValueOnce(updated);
 
     const result = await useCase.execute('u1', 'r1');
 
     expect(roleRepo.findOneOrFail).toHaveBeenCalledWith({
       where: { id: 'r1' },
     });
-    expect(current.roles).toEqual([existingRole, newRole]);
+    // Vérifie sur les ids seulement (robuste)
+    expect(current.roles.map((r) => r.id)).toEqual([
+      existingRole.id,
+      newRole.id,
+    ]);
     expect(repo.save).toHaveBeenCalledWith(current);
     expect(dataSource.transaction).toHaveBeenCalled();
     expect(result).toEqual(new UserResponseDto(updated));
   });
 
-  it('should not add duplicate role', async () => {
+  it('should not add duplicate role and remove role, assign GUEST if no roles left', async () => {
     const existingRole = createMockRole({ id: 'r1', isAdmin: true });
-    const otherRole = createMockRole({ id: 'r2', isAdmin: false });
     const current = createMockUser({
       id: 'u1',
-      roles: [existingRole, otherRole],
+      roles: [existingRole],
     });
-    const updated = Object.setPrototypeOf(current, User.prototype);
-
     const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });
 
-    repo.findOneOrFail.mockResolvedValue(current);
+    repo.findOneOrFail.mockResolvedValueOnce(current); // user
     roleRepo.findOneOrFail
-      .mockResolvedValueOnce(existingRole)
-      .mockResolvedValueOnce(guestRole);
-    repo.save.mockResolvedValue(updated);
+      .mockResolvedValueOnce(existingRole) // find role to remove
+      .mockResolvedValueOnce(guestRole); // assign guest
+
+    const updated = Object.setPrototypeOf(
+      { ...current, roles: [guestRole] },
+      User.prototype,
+    );
+    repo.save.mockResolvedValueOnce(updated);
 
     const result = await useCase.execute('u1', 'r1');
 
@@ -85,8 +97,8 @@ describe('UpdateUserRoleUseCase', () => {
     });
     const updated = Object.setPrototypeOf(current, User.prototype);
 
-    repo.findOneOrFail.mockResolvedValue(current);
-    repo.save.mockResolvedValue(updated);
+    repo.findOneOrFail.mockResolvedValueOnce(current);
+    repo.save.mockResolvedValueOnce(updated);
 
     const result = await useCase.execute('u1', null);
 
@@ -101,16 +113,16 @@ describe('UpdateUserRoleUseCase', () => {
     const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });
     const current = createMockUser({ id: 'u1', roles: [existingRole] });
 
-    repo.findOneOrFail.mockResolvedValueOnce(current); // for user
+    repo.findOneOrFail.mockResolvedValueOnce(current); // user
     roleRepo.findOneOrFail
       .mockResolvedValueOnce(existingRole) // find role to remove
-      .mockResolvedValueOnce(guestRole); // find guest role
+      .mockResolvedValueOnce(guestRole); // assign guest
 
     const updated = Object.setPrototypeOf(
       { ...current, roles: [guestRole] },
       User.prototype,
     );
-    repo.save.mockResolvedValue(updated);
+    repo.save.mockResolvedValueOnce(updated);
 
     const result = await useCase.execute('u1', 'r1');
 
@@ -123,8 +135,8 @@ describe('UpdateUserRoleUseCase', () => {
     const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });
     const current = createMockUser({ id: 'u1', roles: [guestRole] });
 
-    repo.findOneOrFail.mockResolvedValueOnce(current); // for user
-    roleRepo.findOneOrFail.mockResolvedValue(guestRole); // for role
+    repo.findOneOrFail.mockResolvedValueOnce(current); // user
+    roleRepo.findOneOrFail.mockResolvedValueOnce(guestRole); // role
 
     await expect(useCase.execute('u1', 'g1')).rejects.toThrow(
       CannotRemoveGuestRoleException,
@@ -136,21 +148,44 @@ describe('UpdateUserRoleUseCase', () => {
     const adminRole = createMockRole({ id: 'a1', isAdmin: true });
     const current = createMockUser({ id: 'u1', roles: [adminRole] });
 
-    repo.findOneByField.mockResolvedValueOnce(current); // for user
-    roleRepo.findOneByField.mockResolvedValue(adminRole); // for role
-    repo.countAdmins.mockResolvedValue(1);
+    repo.findOneOrFail.mockResolvedValueOnce(current); // user
+    roleRepo.findOneOrFail.mockResolvedValueOnce(adminRole); // role
+    repo.count.mockResolvedValueOnce(1); // only 1 admin in system
 
     await expect(useCase.execute('u1', 'a1')).rejects.toThrow(
       CannotRemoveLastAdminException,
     );
-
-    expect(repo.countAdmins).toHaveBeenCalled();
+    expect(repo.count).toHaveBeenCalledWith({
+      where: { roles: { isAdmin: true } },
+    });
+    expect(dataSource.transaction).toHaveBeenCalled();
   });
 
   it('should propagate errors', async () => {
-    repo.findOneOrFail.mockResolvedValue(createMockUser({ roles: [] }));
-    repo.save.mockRejectedValue(new Error('fail'));
+    repo.findOneOrFail.mockResolvedValueOnce(createMockUser({ roles: [] }));
+    repo.save.mockRejectedValueOnce(new Error('fail'));
     await expect(useCase.execute('u1', null)).rejects.toThrow('fail');
     expect(dataSource.transaction).toHaveBeenCalled();
+  });
+
+  it('should assign GUEST if user starts with no roles and removes one', async () => {
+    const emptyUser = createMockUser({ id: 'u1', roles: [] });
+    const toRemoveRole = createMockRole({ id: 'r1', name: 'USER' });
+    const guestRole = createMockRole({ id: 'g1', name: 'GUEST' });
+
+    repo.findOneOrFail.mockResolvedValueOnce(emptyUser); // user
+    roleRepo.findOneOrFail
+      .mockResolvedValueOnce(toRemoveRole)
+      .mockResolvedValueOnce(guestRole);
+    const updated = Object.setPrototypeOf(
+      { ...emptyUser, roles: [guestRole] },
+      User.prototype,
+    );
+    repo.save.mockResolvedValueOnce(updated);
+
+    const result = await useCase.execute('u1', 'r1');
+
+    expect(emptyUser.roles).toEqual([guestRole]);
+    expect(result).toEqual(new UserResponseDto(updated));
   });
 });

--- a/src/modules/roles/application/use-cases/update-user-role.use-case.ts
+++ b/src/modules/roles/application/use-cases/update-user-role.use-case.ts
@@ -3,6 +3,7 @@ import { UserResponseDto } from '@/modules/users/application/dto/user.response.d
 import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
 import { RoleRepositoryInterface } from '../../domain/interfaces/role.repository.interface';
 import { CannotRemoveGuestRoleException } from '../../domain/exceptions/role.exception';
+import { CannotRemoveLastAdminException } from '@/modules/users/domain/exceptions/user.exception';
 
 @Injectable()
 export class UpdateUserRoleUseCase {
@@ -45,6 +46,12 @@ export class UpdateUserRoleUseCase {
       } else {
         if (role.name === 'GUEST' && current.roles.length === 1) {
           throw new CannotRemoveGuestRoleException();
+        }
+        if (role.isAdmin) {
+          const adminRoles = current.roles.filter((r) => r.isAdmin);
+          if (adminRoles.length === 1 && (await this.repo.countAdmins()) === 1) {
+            throw new CannotRemoveLastAdminException();
+          }
         }
         current.roles = current.roles.filter((r) => r.id !== roleId);
         if (current.roles.length === 0) {

--- a/src/modules/users/domain/exceptions/user.exception.ts
+++ b/src/modules/users/domain/exceptions/user.exception.ts
@@ -42,3 +42,9 @@ export class CannotDeleteLastAdminException extends Error {
     super(message);
   }
 }
+
+export class CannotRemoveLastAdminException extends Error {
+  constructor(message = 'Impossible de retirer le dernier rôle administrateur') {
+    super(message);
+  }
+}


### PR DESCRIPTION
## Summary
- add `CannotRemoveLastAdminException`
- catch new exception in `UserExceptionFilter`
- prevent removing the last admin role from users
- update role use case tests