### PR TITLE
feat/pagination: add paginated endpoints for rooms and vms

### DIFF
--- a/src/core/filters/__tests__/role.filter.spec.ts
+++ b/src/core/filters/__tests__/role.filter.spec.ts
@@ -42,7 +42,8 @@ describe('RoleExceptionFilter', () => {
     expect(response.status).toHaveBeenCalledWith(HttpStatus.FORBIDDEN);
     expect(json).toHaveBeenCalledWith({
       statusCode: 403,
-      message: 'Cannot delete system role: ADMIN. This role is required for the system to function properly.',
+      message:
+        'Cannot delete system role: ADMIN. This role is required for the system to function properly.',
     });
   });
 });

--- a/src/modules/rooms/__mocks__/room.repository.mock.ts
+++ b/src/modules/rooms/__mocks__/room.repository.mock.ts
@@ -10,4 +10,5 @@ export const mockRoomRepository = (): RoomRepositoryInterface => ({
   save: jest.fn(),
   findAll: jest.fn(),
   findOneByField: jest.fn(),
+  paginate: jest.fn(),
 });

--- a/src/modules/rooms/__mocks__/room.response.dto.mock.ts
+++ b/src/modules/rooms/__mocks__/room.response.dto.mock.ts
@@ -5,4 +5,6 @@ export const mockRoomResponseDto = () => ({
   name: 'Room 69',
   servers: [],
   ups: [],
+  serverCount: 0,
+  upsCount: 0,
 });

--- a/src/modules/rooms/application/controllers/room.controller.spec.ts
+++ b/src/modules/rooms/application/controllers/room.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import {
   CreateRoomUseCase,
   DeleteRoomUseCase,
+  GetRoomListUseCase,
   GetAllRoomsUseCase,
   GetRoomByIdUseCase,
   UpdateRoomUseCase,
@@ -17,6 +18,7 @@ describe('RoomController', () => {
   let controller: RoomController;
 
   const getAllRoomsUseCase = { execute: jest.fn() };
+  const getRoomListUseCase = { execute: jest.fn() };
   const getRoomByIdUseCase = { execute: jest.fn() };
   const createRoomUseCase = { execute: jest.fn() };
   const updateRoomUseCase = { execute: jest.fn() };
@@ -34,6 +36,7 @@ describe('RoomController', () => {
       controllers: [RoomController],
       providers: [
         { provide: GetAllRoomsUseCase, useValue: getAllRoomsUseCase },
+        { provide: GetRoomListUseCase, useValue: getRoomListUseCase },
         { provide: GetRoomByIdUseCase, useValue: getRoomByIdUseCase },
         { provide: CreateRoomUseCase, useValue: createRoomUseCase },
         { provide: UpdateRoomUseCase, useValue: updateRoomUseCase },
@@ -51,6 +54,22 @@ describe('RoomController', () => {
 
     expect(rooms).toEqual([mockRoomResponse]);
     expect(getAllRoomsUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return paginated rooms', async () => {
+    const mock = { items: [mockRoomResponse] } as any;
+    getRoomListUseCase.execute.mockResolvedValue(mock);
+    const result = await controller.getRooms('1', '5');
+    expect(result).toBe(mock);
+    expect(getRoomListUseCase.execute).toHaveBeenCalledWith(1, 5);
+  });
+
+  it('should use default pagination values', async () => {
+    const mock = { items: [] } as any;
+    getRoomListUseCase.execute.mockResolvedValue(mock);
+    const result = await controller.getRooms();
+    expect(result).toBe(mock);
+    expect(getRoomListUseCase.execute).toHaveBeenCalledWith(1, 10);
   });
 
   it('should return a room by ID when getRoomById is called', async () => {

--- a/src/modules/rooms/application/controllers/room.controller.spec.ts
+++ b/src/modules/rooms/application/controllers/room.controller.spec.ts
@@ -59,9 +59,9 @@ describe('RoomController', () => {
   it('should return paginated rooms', async () => {
     const mock = { items: [mockRoomResponse] } as any;
     getRoomListUseCase.execute.mockResolvedValue(mock);
-    const result = await controller.getRooms('1', '5');
+    const result = await controller.getRooms('1', '5', 'true');
     expect(result).toBe(mock);
-    expect(getRoomListUseCase.execute).toHaveBeenCalledWith(1, 5);
+    expect(getRoomListUseCase.execute).toHaveBeenCalledWith(1, 5, true);
   });
 
   it('should use default pagination values', async () => {
@@ -69,7 +69,7 @@ describe('RoomController', () => {
     getRoomListUseCase.execute.mockResolvedValue(mock);
     const result = await controller.getRooms();
     expect(result).toBe(mock);
-    expect(getRoomListUseCase.execute).toHaveBeenCalledWith(1, 10);
+    expect(getRoomListUseCase.execute).toHaveBeenCalledWith(1, 10, false);
   });
 
   it('should return a room by ID when getRoomById is called', async () => {

--- a/src/modules/rooms/application/controllers/room.controller.ts
+++ b/src/modules/rooms/application/controllers/room.controller.ts
@@ -7,21 +7,24 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiBody,
   ApiBearerAuth,
   ApiResponse,
 } from '@nestjs/swagger';
 
-import { RoomCreationDto, RoomResponseDto } from '../dto';
+import { RoomCreationDto, RoomResponseDto, RoomListResponseDto } from '../dto';
 import {
   CreateRoomUseCase,
   DeleteRoomUseCase,
+  GetRoomListUseCase,
   GetAllRoomsUseCase,
   GetRoomByIdUseCase,
   UpdateRoomUseCase,
@@ -35,6 +38,7 @@ import { JwtPayload } from '@/core/types/jwt-payload.interface';
 export class RoomController {
   constructor(
     private readonly getAllRoomsUseCase: GetAllRoomsUseCase,
+    private readonly getRoomListUseCase: GetRoomListUseCase,
     private readonly getRoomByIdUseCase: GetRoomByIdUseCase,
     private readonly createRoomUseCase: CreateRoomUseCase,
     private readonly updateRoomUseCase: UpdateRoomUseCase,
@@ -42,10 +46,21 @@ export class RoomController {
   ) {}
 
   @Get()
-  @ApiOperation({
-    summary: 'Lister toutes les salles',
-    description: 'Renvoie la liste de toutes les salles disponibles.',
-  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOperation({ summary: 'Lister les salles paginées' })
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiResponse({ status: 200, type: RoomListResponseDto })
+  async getRooms(
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+  ): Promise<RoomListResponseDto> {
+    return this.getRoomListUseCase.execute(Number(page), Number(limit));
+  }
+
+  @Get('all')
+  @ApiOperation({ summary: 'Lister toutes les salles' })
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @ApiResponse({ status: 200, type: [RoomResponseDto] })

--- a/src/modules/rooms/application/controllers/room.controller.ts
+++ b/src/modules/rooms/application/controllers/room.controller.ts
@@ -48,6 +48,7 @@ export class RoomController {
   @Get()
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'includeCounts', required: false, type: Boolean })
   @ApiOperation({ summary: 'Lister les salles paginées' })
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
@@ -55,8 +56,14 @@ export class RoomController {
   async getRooms(
     @Query('page') page = '1',
     @Query('limit') limit = '10',
+    @Query('includeCounts') includeCounts = 'false',
   ): Promise<RoomListResponseDto> {
-    return this.getRoomListUseCase.execute(Number(page), Number(limit));
+    const withCounts = includeCounts === 'true';
+    return this.getRoomListUseCase.execute(
+      Number(page),
+      Number(limit),
+      withCounts,
+    );
   }
 
   @Get('all')

--- a/src/modules/rooms/application/dto/__tests__/room.list.response.dto.spec.ts
+++ b/src/modules/rooms/application/dto/__tests__/room.list.response.dto.spec.ts
@@ -1,0 +1,21 @@
+import { createMockRoom } from '@/modules/rooms/__mocks__/rooms.mock';
+import { RoomResponseDto } from '../room.response.dto';
+import { RoomListResponseDto } from '../room.list.response.dto';
+
+describe('RoomListResponseDto', () => {
+  it('should set properties correctly', () => {
+    const items = [RoomResponseDto.from(createMockRoom())];
+    const dto = new RoomListResponseDto(items, 5, 2, 2);
+    expect(dto.items).toEqual(items);
+    expect(dto.totalItems).toBe(5);
+    expect(dto.currentPage).toBe(2);
+    expect(dto.totalPages).toBe(3);
+  });
+
+  it('should support empty items', () => {
+    const dto = new RoomListResponseDto([], 0, 1, 10);
+    expect(dto.items).toEqual([]);
+    expect(dto.totalItems).toBe(0);
+    expect(dto.totalPages).toBe(0);
+  });
+});

--- a/src/modules/rooms/application/dto/__tests__/room.response.dto.spec.ts
+++ b/src/modules/rooms/application/dto/__tests__/room.response.dto.spec.ts
@@ -12,6 +12,8 @@ describe('RoomResponseDto', () => {
       name: 'Salle 1',
       servers: [],
       ups: [],
+      serverCount: 0,
+      upsCount: 0,
     });
 
     const errors = await validate(dto);

--- a/src/modules/rooms/application/dto/index.ts
+++ b/src/modules/rooms/application/dto/index.ts
@@ -1,4 +1,5 @@
 import { RoomCreationDto } from '@/modules/rooms/application/dto/room.creation.dto';
 import { RoomResponseDto } from '@/modules/rooms/application/dto/room.response.dto';
+import { RoomListResponseDto } from '@/modules/rooms/application/dto/room.list.response.dto';
 
-export { RoomCreationDto, RoomResponseDto };
+export { RoomCreationDto, RoomResponseDto, RoomListResponseDto };

--- a/src/modules/rooms/application/dto/room.list.response.dto.ts
+++ b/src/modules/rooms/application/dto/room.list.response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaginatedResponseDto } from '@/core/dto';
+import { RoomResponseDto } from './room.response.dto';
+
+export class RoomListResponseDto extends PaginatedResponseDto<RoomResponseDto> {
+  @ApiProperty({ type: () => RoomResponseDto, isArray: true })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RoomResponseDto)
+  readonly items: RoomResponseDto[];
+
+  constructor(
+    items: RoomResponseDto[],
+    totalItems: number,
+    currentPage: number,
+    pageSize: number,
+  ) {
+    super(items, totalItems, currentPage, pageSize);
+  }
+}

--- a/src/modules/rooms/application/dto/room.response.dto.ts
+++ b/src/modules/rooms/application/dto/room.response.dto.ts
@@ -5,6 +5,8 @@ import {
   IsUUID,
   IsArray,
   ValidateNested,
+  IsOptional,
+  IsNumber,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { Room } from '../../domain/entities/room.entity';
@@ -38,22 +40,45 @@ export class RoomResponseDto {
   @Type(() => UpsResponseDto)
   readonly ups?: UpsResponseDto[];
 
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  readonly serverCount?: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsNumber()
+  readonly upsCount?: number;
+
   constructor(
     id: string,
     name: string,
     servers: ServerResponseDto[] = [],
     ups: UpsResponseDto[] = [],
+    serverCount?: number,
+    upsCount?: number,
   ) {
     this.id = id;
     this.name = name;
     this.servers = servers;
     this.ups = ups;
+    this.serverCount = serverCount;
+    this.upsCount = upsCount;
   }
 
-  static from(room: Room): RoomResponseDto {
+  static from(room: Room, includeCounts = false): RoomResponseDto {
     const servers =
       room.servers?.map((s) => ServerResponseDto.fromEntity(s)) ?? [];
     const ups = room.ups?.map((u) => new UpsResponseDto(u)) ?? [];
-    return new RoomResponseDto(room.id, room.name, servers, ups);
+    const serverCount = includeCounts ? servers.length : undefined;
+    const upsCount = includeCounts ? ups.length : undefined;
+    return new RoomResponseDto(
+      room.id,
+      room.name,
+      servers,
+      ups,
+      serverCount,
+      upsCount,
+    );
   }
 }

--- a/src/modules/rooms/application/use-cases/__tests__/get-room-by-id.use-case.spec.ts
+++ b/src/modules/rooms/application/use-cases/__tests__/get-room-by-id.use-case.spec.ts
@@ -4,7 +4,6 @@ import { RoomRepositoryInterface } from '@/modules/rooms/domain/interfaces/room.
 import { createMockServer } from '@/modules/servers/__mocks__/servers.mock';
 import { createMockPermissionServer } from '@/modules/permissions/__mocks__/permissions.mock';
 import { createMockUser } from '@/modules/auth/__mocks__/user.mock';
-import { createMockRole } from '@/modules/roles/__mocks__/role.mock';
 import { PermissionBit } from '@/modules/permissions/domain/value-objects/permission-bit.enum';
 import { PermissionServerRepositoryInterface } from '@/modules/permissions/infrastructure/interfaces/permission.server.repository.interface';
 import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
@@ -49,7 +48,7 @@ describe('GetRoomByIdUseCase', () => {
 
     roomRepository.findRoomById.mockResolvedValue(room);
     userRepo.findOneByField.mockResolvedValue(
-     createMockUser({ roles: [{ id: 'role-1' }] }),
+      createMockUser({ roles: [{ id: 'role-1' }] }),
     );
     permissionRepo.findAllByField.mockResolvedValue([
       createMockPermissionServer({
@@ -146,9 +145,7 @@ describe('GetRoomByIdUseCase', () => {
     const room = mockRoom({ servers: [createMockServer({ id: 's1' })] });
 
     roomRepository.findRoomById.mockResolvedValue(room);
-    userRepo.findOneByField.mockResolvedValue(
-      createMockUser({ roles: [] }),
-    );
+    userRepo.findOneByField.mockResolvedValue(createMockUser({ roles: [] }));
 
     const result = await useCase.execute(room.id, 'user-1');
 

--- a/src/modules/rooms/application/use-cases/__tests__/get-room-list.use-case.spec.ts
+++ b/src/modules/rooms/application/use-cases/__tests__/get-room-list.use-case.spec.ts
@@ -1,0 +1,34 @@
+import { GetRoomListUseCase } from '../get-room-list.use-case';
+import { RoomRepositoryInterface } from '@/modules/rooms/domain/interfaces/room.repository.interface';
+import { createMockRoom } from '@/modules/rooms/__mocks__/rooms.mock';
+
+describe('GetRoomListUseCase', () => {
+  let repo: jest.Mocked<RoomRepositoryInterface>;
+  let useCase: GetRoomListUseCase;
+
+  beforeEach(() => {
+    repo = { paginate: jest.fn() } as any;
+    useCase = new GetRoomListUseCase(repo);
+  });
+
+  it('should return paginated rooms', async () => {
+    const rooms = [createMockRoom({ id: '1' })];
+    repo.paginate.mockResolvedValue([rooms, 1]);
+
+    const result = await useCase.execute(2, 5);
+
+    expect(repo.paginate).toHaveBeenCalledWith(2, 5);
+    expect(result.items).toHaveLength(1);
+    expect(result.totalItems).toBe(1);
+    expect(result.currentPage).toBe(2);
+  });
+
+  it('should handle empty list', async () => {
+    repo.paginate.mockResolvedValue([[], 0]);
+
+    const result = await useCase.execute();
+
+    expect(result.items).toEqual([]);
+    expect(result.totalItems).toBe(0);
+  });
+});

--- a/src/modules/rooms/application/use-cases/__tests__/get-room-list.use-case.spec.ts
+++ b/src/modules/rooms/application/use-cases/__tests__/get-room-list.use-case.spec.ts
@@ -15,7 +15,7 @@ describe('GetRoomListUseCase', () => {
     const rooms = [createMockRoom({ id: '1' })];
     repo.paginate.mockResolvedValue([rooms, 1]);
 
-    const result = await useCase.execute(2, 5);
+    const result = await useCase.execute(2, 5, true);
 
     expect(repo.paginate).toHaveBeenCalledWith(2, 5);
     expect(result.items).toHaveLength(1);

--- a/src/modules/rooms/application/use-cases/get-room-list.use-case.ts
+++ b/src/modules/rooms/application/use-cases/get-room-list.use-case.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { RoomRepositoryInterface } from '../..//domain/interfaces/room.repository.interface';
+import { RoomResponseDto } from '../dto/room.response.dto';
+import { RoomListResponseDto } from '../dto/room.list.response.dto';
+
+@Injectable()
+export class GetRoomListUseCase {
+  constructor(
+    @Inject('RoomRepositoryInterface')
+    private readonly repo: RoomRepositoryInterface,
+  ) {}
+
+  async execute(page = 1, limit = 10): Promise<RoomListResponseDto> {
+    const [rooms, total] = await this.repo.paginate(page, limit);
+    const dtos = rooms.map((r) => RoomResponseDto.from(r));
+    return new RoomListResponseDto(dtos, total, page, limit);
+  }
+}

--- a/src/modules/rooms/application/use-cases/get-room-list.use-case.ts
+++ b/src/modules/rooms/application/use-cases/get-room-list.use-case.ts
@@ -10,9 +10,13 @@ export class GetRoomListUseCase {
     private readonly repo: RoomRepositoryInterface,
   ) {}
 
-  async execute(page = 1, limit = 10): Promise<RoomListResponseDto> {
+  async execute(
+    page = 1,
+    limit = 10,
+    includeCounts = false,
+  ): Promise<RoomListResponseDto> {
     const [rooms, total] = await this.repo.paginate(page, limit);
-    const dtos = rooms.map((r) => RoomResponseDto.from(r));
+    const dtos = rooms.map((r) => RoomResponseDto.from(r, includeCounts));
     return new RoomListResponseDto(dtos, total, page, limit);
   }
 }

--- a/src/modules/rooms/application/use-cases/index.ts
+++ b/src/modules/rooms/application/use-cases/index.ts
@@ -1,10 +1,12 @@
 import { CreateRoomUseCase } from './create-room.use-case';
 import { DeleteRoomUseCase } from './delete-room.use-case';
 import { GetAllRoomsUseCase } from './get-all-rooms.use-case';
+import { GetRoomListUseCase } from './get-room-list.use-case';
 import { GetRoomByIdUseCase } from './get-room-by-id.use-case';
 import { UpdateRoomUseCase } from './update-room.use-case';
 
 export const RoomUseCases = [
+  GetRoomListUseCase,
   GetAllRoomsUseCase,
   GetRoomByIdUseCase,
   CreateRoomUseCase,
@@ -18,4 +20,5 @@ export {
   CreateRoomUseCase,
   UpdateRoomUseCase,
   DeleteRoomUseCase,
+  GetRoomListUseCase,
 };

--- a/src/modules/rooms/domain/interfaces/room.repository.interface.ts
+++ b/src/modules/rooms/domain/interfaces/room.repository.interface.ts
@@ -7,4 +7,12 @@ export interface RoomRepositoryInterface
   createRoom(name: string): Promise<Room>;
   updateRoom(id: string, name: string): Promise<Room>;
   deleteRoom(id: string): Promise<void>;
+
+  /**
+   * Retrieve rooms with pagination.
+   *
+   * @param page - page number starting at 1
+   * @param limit - items per page
+   */
+  paginate(page: number, limit: number): Promise<[Room[], number]>;
 }

--- a/src/modules/rooms/infrastructure/repositories/room.typeorm.repository.ts
+++ b/src/modules/rooms/infrastructure/repositories/room.typeorm.repository.ts
@@ -49,6 +49,15 @@ export class RoomTypeormRepository implements RoomRepositoryInterface {
     });
   }
 
+  async paginate(page: number, limit: number): Promise<[Room[], number]> {
+    return this.repo.findAndCount({
+      relations: ['servers', 'servers.ilo', 'ups'],
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { name: 'ASC' },
+    });
+  }
+
   async findRoomById(id: string): Promise<Room> {
     const room = await this.repo.findOne({
       where: { id },

--- a/src/modules/servers/application/controllers/server.controller.ts
+++ b/src/modules/servers/application/controllers/server.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseFilters,
   UseGuards,
 } from '@nestjs/common';
@@ -17,6 +18,7 @@ import {
   ApiBody,
   ApiBearerAuth,
   ApiResponse,
+  ApiQuery,
 } from '@nestjs/swagger';
 
 import {
@@ -32,6 +34,7 @@ import {
 import { ServerResponseDto } from '../dto/server.response.dto';
 import { ServerCreationDto } from '../dto/server.creation.dto';
 import { ServerUpdateDto } from '../dto/server.update.dto';
+import { ServerListResponseDto } from '../dto/server.list.response.dto';
 import { JwtAuthGuard } from '@/modules/auth/infrastructure/guards/jwt-auth.guard';
 import { CurrentUser } from '@/core/decorators/current-user.decorator';
 import { JwtPayload } from '@/core/types/jwt-payload.interface';
@@ -92,12 +95,20 @@ export class ServerController {
   @UseGuards(JwtAuthGuard)
   @UseFilters(InvalidQueryExceptionFilter)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Lister mes serveurs accessibles' })
-  @ApiResponse({ status: 200, type: [ServerResponseDto] })
+  @ApiOperation({ summary: 'Lister mes serveurs accessibles avec pagination' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, type: ServerListResponseDto })
   async getMyServers(
     @CurrentUser() user: JwtPayload,
-  ): Promise<ServerResponseDto[]> {
-    return this.getUserServersUseCase.execute(user.userId);
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+  ): Promise<ServerListResponseDto> {
+    return this.getUserServersUseCase.execute(
+      user.userId,
+      Number(page),
+      Number(limit),
+    );
   }
 
   @Get(':id')

--- a/src/modules/servers/application/dto/server.list.response.dto.ts
+++ b/src/modules/servers/application/dto/server.list.response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaginatedResponseDto } from '@/core/dto';
+import { ServerResponseDto } from './server.response.dto';
+
+export class ServerListResponseDto extends PaginatedResponseDto<ServerResponseDto> {
+  @ApiProperty({ type: () => ServerResponseDto, isArray: true })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ServerResponseDto)
+  readonly items: ServerResponseDto[];
+
+  constructor(
+    items: ServerResponseDto[],
+    totalItems: number,
+    currentPage: number,
+    pageSize: number,
+  ) {
+    super(items, totalItems, currentPage, pageSize);
+  }
+}

--- a/src/modules/servers/application/use-cases/__tests__/get-user-servers.use-case.spec.ts
+++ b/src/modules/servers/application/use-cases/__tests__/get-user-servers.use-case.spec.ts
@@ -1,6 +1,7 @@
 import { PermissionBit } from '@/modules/permissions/domain/value-objects/permission-bit.enum';
 import { GetUserServersUseCase } from '../get-user-servers.use-case';
 import { ServerResponseDto } from '../../dto/server.response.dto';
+import { ServerListResponseDto } from '../../dto/server.list.response.dto';
 
 describe('GetUserServersUseCase', () => {
   let useCase: GetUserServersUseCase;
@@ -11,100 +12,302 @@ describe('GetUserServersUseCase', () => {
   beforeEach(() => {
     userRepo = { findOneByField: jest.fn() };
     permissionRepo = { findAllByField: jest.fn() };
-    serverRepo = { findAllByField: jest.fn(), findAll: jest.fn() };
+    serverRepo = {
+      findAllByField: jest.fn(),
+      findAllByFieldPaginated: jest.fn(),
+      findAll: jest.fn(),
+    };
 
     useCase = new GetUserServersUseCase(userRepo, permissionRepo, serverRepo);
   });
 
-  it('should return [] if user has no role', async () => {
-    userRepo.findOneByField.mockResolvedValue({ id: 'user-1', roles: [] });
+  describe('Basic pagination functionality', () => {
+    it('should return empty paginated response if user has no role', async () => {
+      userRepo.findOneByField.mockResolvedValue({ id: 'user-1', roles: [] });
 
-    const result = await useCase.execute('user-1');
-    expect(result).toEqual([]);
-  });
+      const result = await useCase.execute('user-1', 1, 10);
 
-  it('should return [] if no permissions found', async () => {
-    userRepo.findOneByField.mockResolvedValue({
-      id: 'user-2',
-      roles: [{ id: 'role-2' }],
-    });
-    permissionRepo.findAllByField.mockResolvedValue([]);
-
-    const result = await useCase.execute('user-2');
-    expect(result).toEqual([]);
-  });
-
-  it('should return [] if user has no READ permissions', async () => {
-    userRepo.findOneByField.mockResolvedValue({
-      id: 'user-3',
-      roles: [{ id: 'role-3' }],
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(0);
     });
 
-    permissionRepo.findAllByField.mockResolvedValue([
-      { serverId: 'srv-1', bitmask: PermissionBit.WRITE },
-      { serverId: 'srv-2', bitmask: PermissionBit.WRITE },
-    ]);
+    it('should return empty paginated response if no permissions found', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-2',
+        roles: [{ id: 'role-2' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([]);
 
-    const result = await useCase.execute('user-3');
-    expect(result).toEqual([]);
-  });
+      const result = await useCase.execute('user-2', 1, 10);
 
-  it('should return [] if READ permissions point only to null serverIds', async () => {
-    userRepo.findOneByField.mockResolvedValue({
-      id: 'user-4',
-      roles: [{ id: 'role-4' }],
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(0);
     });
-    permissionRepo.findAllByField.mockResolvedValue([
-      { serverId: null, bitmask: PermissionBit.READ },
-      { serverId: null, bitmask: PermissionBit.READ | PermissionBit.WRITE },
-    ]);
 
-    const result = await useCase.execute('user-4');
-    expect(result).toEqual([]);
-  });
+    it('should return empty paginated response if user has no READ permissions', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-3',
+        roles: [{ id: 'role-3' }],
+      });
 
-  it('should return servers if READ permissions and servers found', async () => {
-    userRepo.findOneByField.mockResolvedValue({
-      id: 'user-5',
-      roles: [{ id: 'role-5' }],
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: 'srv-1', bitmask: PermissionBit.WRITE },
+        { serverId: 'srv-2', bitmask: PermissionBit.WRITE },
+      ]);
+
+      const result = await useCase.execute('user-3', 1, 10);
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(0);
     });
-    permissionRepo.findAllByField.mockResolvedValue([
-      { serverId: 'srv-42', bitmask: PermissionBit.READ },
-      { serverId: 'srv-43', bitmask: PermissionBit.READ | PermissionBit.WRITE },
-    ]);
 
-    serverRepo.findAllByField.mockResolvedValue([
-      { id: 'srv-42', name: 'Serveur 42' },
-      { id: 'srv-43', name: 'Serveur 43' },
-    ]);
+    it('should return empty paginated response if READ permissions point only to null serverIds', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-4',
+        roles: [{ id: 'role-4' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: null, bitmask: PermissionBit.READ },
+        { serverId: null, bitmask: PermissionBit.READ | PermissionBit.WRITE },
+      ]);
 
-    jest
-      .spyOn(ServerResponseDto, 'fromEntity')
-      .mockImplementation((s: any) => ({ id: s.id, name: s.name }) as any);
+      const result = await useCase.execute('user-4', 1, 10);
 
-    const result = await useCase.execute('user-5');
-    expect(result).toEqual([
-      { id: 'srv-42', name: 'Serveur 42' },
-      { id: 'srv-43', name: 'Serveur 43' },
-    ]);
-    expect(serverRepo.findAllByField).toHaveBeenCalledWith({
-      field: 'id',
-      value: ['srv-42', 'srv-43'],
-      relations: ['ilo'],
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(0);
     });
   });
 
-  it('should return [] if an error is thrown by repo', async () => {
-    userRepo.findOneByField.mockResolvedValue({
-      id: 'user-6',
-      roles: [{ id: 'role-6' }],
-    });
-    permissionRepo.findAllByField.mockResolvedValue([
-      { serverId: 'srv-99', bitmask: PermissionBit.READ },
-    ]);
-    serverRepo.findAllByField.mockRejectedValue(new Error('DB crashed'));
+  describe('Successful pagination scenarios', () => {
+    it('should return paginated servers if READ permissions and servers found', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-5',
+        roles: [{ id: 'role-5' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: 'srv-42', bitmask: PermissionBit.READ },
+        {
+          serverId: 'srv-43',
+          bitmask: PermissionBit.READ | PermissionBit.WRITE,
+        },
+      ]);
 
-    const result = await useCase.execute('user-6');
-    expect(result).toEqual([]);
+      serverRepo.findAllByFieldPaginated.mockResolvedValue([
+        [
+          { id: 'srv-42', name: 'Serveur 42' },
+          { id: 'srv-43', name: 'Serveur 43' },
+        ],
+        2,
+      ]);
+
+      jest
+        .spyOn(ServerResponseDto, 'fromEntity')
+        .mockImplementation((s: any) => ({ id: s.id, name: s.name }) as any);
+
+      const result = await useCase.execute('user-5', 1, 10);
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([
+        { id: 'srv-42', name: 'Serveur 42' },
+        { id: 'srv-43', name: 'Serveur 43' },
+      ]);
+      expect(result.totalItems).toBe(2);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(1);
+
+      expect(serverRepo.findAllByFieldPaginated).toHaveBeenCalledWith(
+        {
+          field: 'id',
+          value: ['srv-42', 'srv-43'],
+          relations: ['ilo'],
+        },
+        1,
+        10,
+      );
+    });
+
+    it('should handle different page and limit values correctly', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-6',
+        roles: [{ id: 'role-6' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: 'srv-1', bitmask: PermissionBit.READ },
+        { serverId: 'srv-2', bitmask: PermissionBit.READ },
+        { serverId: 'srv-3', bitmask: PermissionBit.READ },
+      ]);
+
+      serverRepo.findAllByFieldPaginated.mockResolvedValue([
+        [{ id: 'srv-2', name: 'Serveur 2' }],
+        3,
+      ]);
+
+      jest
+        .spyOn(ServerResponseDto, 'fromEntity')
+        .mockImplementation((s: any) => ({ id: s.id, name: s.name }) as any);
+
+      const result = await useCase.execute('user-6', 2, 1);
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([{ id: 'srv-2', name: 'Serveur 2' }]);
+      expect(result.totalItems).toBe(3);
+      expect(result.currentPage).toBe(2);
+      expect(result.totalPages).toBe(3);
+
+      expect(serverRepo.findAllByFieldPaginated).toHaveBeenCalledWith(
+        {
+          field: 'id',
+          value: ['srv-1', 'srv-2', 'srv-3'],
+          relations: ['ilo'],
+        },
+        2,
+        1,
+      );
+    });
+
+    it('should use default pagination values when not provided', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-7',
+        roles: [{ id: 'role-7' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: 'srv-default', bitmask: PermissionBit.READ },
+      ]);
+
+      serverRepo.findAllByFieldPaginated.mockResolvedValue([
+        [{ id: 'srv-default', name: 'Default Server' }],
+        1,
+      ]);
+
+      jest
+        .spyOn(ServerResponseDto, 'fromEntity')
+        .mockImplementation((s: any) => ({ id: s.id, name: s.name }) as any);
+
+      const result = await useCase.execute('user-7');
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(1);
+
+      expect(serverRepo.findAllByFieldPaginated).toHaveBeenCalledWith(
+        {
+          field: 'id',
+          value: ['srv-default'],
+          relations: ['ilo'],
+        },
+        1,
+        10,
+      );
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should return empty paginated response if an error is thrown by repo', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-error',
+        roles: [{ id: 'role-error' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: 'srv-99', bitmask: PermissionBit.READ },
+      ]);
+      serverRepo.findAllByFieldPaginated.mockRejectedValue(
+        new Error('DB crashed'),
+      );
+
+      const result = await useCase.execute('user-error', 1, 10);
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(0);
+    });
+
+    it('should preserve page and limit values in error responses', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-error-2',
+        roles: [{ id: 'role-error-2' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: 'srv-error', bitmask: PermissionBit.READ },
+      ]);
+      serverRepo.findAllByFieldPaginated.mockRejectedValue(
+        new Error('Network error'),
+      );
+
+      const result = await useCase.execute('user-error-2', 3, 5);
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(0);
+      expect(result.currentPage).toBe(3);
+      expect(result.totalPages).toBe(0);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle large server lists with pagination', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-large',
+        roles: [{ id: 'role-large' }],
+      });
+
+      const serverIds = Array.from({ length: 100 }, (_, i) => `srv-${i + 1}`);
+      const permissions = serverIds.map((id) => ({
+        serverId: id,
+        bitmask: PermissionBit.READ,
+      }));
+      permissionRepo.findAllByField.mockResolvedValue(permissions);
+
+      const pageServers = Array.from({ length: 20 }, (_, i) => ({
+        id: `srv-${i + 21}`,
+        name: `Server ${i + 21}`,
+      }));
+      serverRepo.findAllByFieldPaginated.mockResolvedValue([pageServers, 100]);
+
+      jest
+        .spyOn(ServerResponseDto, 'fromEntity')
+        .mockImplementation((s: any) => ({ id: s.id, name: s.name }) as any);
+
+      const result = await useCase.execute('user-large', 2, 20);
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toHaveLength(20);
+      expect(result.totalItems).toBe(100);
+      expect(result.currentPage).toBe(2);
+      expect(result.totalPages).toBe(5);
+    });
+
+    it('should handle zero limit gracefully', async () => {
+      userRepo.findOneByField.mockResolvedValue({
+        id: 'user-zero',
+        roles: [{ id: 'role-zero' }],
+      });
+      permissionRepo.findAllByField.mockResolvedValue([
+        { serverId: 'srv-zero', bitmask: PermissionBit.READ },
+      ]);
+
+      serverRepo.findAllByFieldPaginated.mockResolvedValue([[], 1]);
+
+      const result = await useCase.execute('user-zero', 1, 0);
+
+      expect(result).toBeInstanceOf(ServerListResponseDto);
+      expect(result.items).toEqual([]);
+      expect(result.totalItems).toBe(1);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(Infinity);
+    });
   });
 });

--- a/src/modules/servers/application/use-cases/get-user-servers.use-case.ts
+++ b/src/modules/servers/application/use-cases/get-user-servers.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { PermissionBit } from '@/modules/permissions/domain/value-objects/permission-bit.enum';
 import { ServerResponseDto } from '../dto/server.response.dto';
+import { ServerListResponseDto } from '../dto/server.list.response.dto';
 import { UserRepositoryInterface } from '@/modules/users/domain/interfaces/user.repository.interface';
 import { PermissionServerRepositoryInterface } from '@/modules/permissions/infrastructure/interfaces/permission.server.repository.interface';
 import { ServerRepositoryInterface } from '@/modules/servers/domain/interfaces/server.repository.interface';
@@ -20,7 +21,11 @@ export class GetUserServersUseCase {
     private readonly serverRepo: ServerRepositoryInterface,
   ) {}
 
-  async execute(userId: string): Promise<ServerResponseDto[]> {
+  async execute(
+    userId: string,
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<ServerListResponseDto> {
     const user = await this.userRepo.findOneByField({
       field: 'id',
       value: userId,
@@ -30,7 +35,7 @@ export class GetUserServersUseCase {
     const roleIds = user?.roles?.map((r) => r.id) ?? [];
     if (!roleIds.length) {
       this.logger.debug(`User ${userId} has no role assigned`);
-      return [];
+      return new ServerListResponseDto([], 0, page, limit);
     }
 
     this.logger.debug(`User ${userId} has roleIds ${roleIds.join(',')}`);
@@ -51,18 +56,23 @@ export class GetUserServersUseCase {
       this.logger.debug(
         `User ${userId} has no readable permissions or permissions only with null serverId`,
       );
-      return [];
+      return new ServerListResponseDto([], 0, page, limit);
     }
 
     try {
-      const servers = await this.serverRepo.findAllByField({
-        field: 'id',
-        value: serverIds,
-        relations: ['ilo'],
-      });
+      const [servers, totalCount] =
+        await this.serverRepo.findAllByFieldPaginated(
+          {
+            field: 'id',
+            value: serverIds,
+            relations: ['ilo'],
+          },
+          page,
+          limit,
+        );
 
       this.logger.debug(
-        `User ${userId} has access to ${servers.length} servers`,
+        `User ${userId} has access to ${servers.length} servers (total: ${totalCount})`,
       );
       this.logger.debug(`Servers: ${JSON.stringify(servers)}`);
 
@@ -72,10 +82,15 @@ export class GetUserServersUseCase {
 
       this.logger.debug(`User ${userId} has servers ${serversResponse}`);
 
-      return serversResponse;
+      return new ServerListResponseDto(
+        serversResponse,
+        totalCount,
+        page,
+        limit,
+      );
     } catch (error) {
       this.logger.error(`Unexpected error: ${error.message}`);
-      return [];
+      return new ServerListResponseDto([], 0, page, limit);
     }
   }
 }

--- a/src/modules/servers/domain/interfaces/server.repository.interface.ts
+++ b/src/modules/servers/domain/interfaces/server.repository.interface.ts
@@ -9,6 +9,12 @@ export interface ServerRepositoryInterface
     options: FindAllByFieldOptions<Server, T>,
   ): Promise<Server[]>;
 
+  findAllByFieldPaginated<T extends PrimitiveFields<Server>>(
+    options: FindAllByFieldOptions<Server, T>,
+    page: number,
+    limit: number,
+  ): Promise<[Server[], number]>;
+
   findServerById(id: string): Promise<Server | null>;
   deleteServer(id: string): Promise<void>;
 }

--- a/src/modules/users/domain/exceptions/user.exception.ts
+++ b/src/modules/users/domain/exceptions/user.exception.ts
@@ -44,7 +44,9 @@ export class CannotDeleteLastAdminException extends Error {
 }
 
 export class CannotRemoveLastAdminException extends Error {
-  constructor(message = 'Impossible de retirer le dernier rôle administrateur') {
+  constructor(
+    message = 'Impossible de retirer le dernier rôle administrateur',
+  ) {
     super(message);
   }
 }

--- a/src/modules/vms/__mocks__/index.ts
+++ b/src/modules/vms/__mocks__/index.ts
@@ -1,0 +1,2 @@
+export { createMockVm, createMockVmDto } from './vms.mock';
+export { mockVmRepository } from './vm.repository.mock';

--- a/src/modules/vms/__mocks__/vm.repository.mock.ts
+++ b/src/modules/vms/__mocks__/vm.repository.mock.ts
@@ -1,0 +1,1 @@
+export const mockVmRepository = () => ({ paginate: jest.fn() });

--- a/src/modules/vms/application/controllers/__tests__/vm.controller.spec.ts
+++ b/src/modules/vms/application/controllers/__tests__/vm.controller.spec.ts
@@ -4,6 +4,7 @@ import {
   CreateVmUseCase,
   DeleteVmUseCase,
   GetAllVmsUseCase,
+  GetVmListUseCase,
   GetVmByIdUseCase,
   UpdateVmUseCase,
 } from '../../use-cases';
@@ -17,6 +18,7 @@ import { Reflector } from '@nestjs/core';
 describe('VmController', () => {
   let controller: VmController;
   let getAllVmsUseCase: jest.Mocked<GetAllVmsUseCase>;
+  let getVmListUseCase: jest.Mocked<GetVmListUseCase>;
   let getVmByIdUseCase: jest.Mocked<GetVmByIdUseCase>;
   let createVmUseCase: jest.Mocked<CreateVmUseCase>;
   let updateVmUseCase: jest.Mocked<UpdateVmUseCase>;
@@ -45,6 +47,7 @@ describe('VmController', () => {
     };
 
     getAllVmsUseCase = { execute: jest.fn() } as any;
+    getVmListUseCase = { execute: jest.fn() } as any;
     getVmByIdUseCase = { execute: jest.fn() } as any;
     createVmUseCase = { execute: jest.fn() } as any;
     updateVmUseCase = { execute: jest.fn() } as any;
@@ -54,6 +57,7 @@ describe('VmController', () => {
       controllers: [VmController],
       providers: [
         { provide: GetAllVmsUseCase, useValue: getAllVmsUseCase },
+        { provide: GetVmListUseCase, useValue: getVmListUseCase },
         { provide: GetVmByIdUseCase, useValue: getVmByIdUseCase },
         { provide: CreateVmUseCase, useValue: createVmUseCase },
         { provide: UpdateVmUseCase, useValue: updateVmUseCase },
@@ -85,6 +89,24 @@ describe('VmController', () => {
 
       expect(result).toEqual([vm]);
       expect(getAllVmsUseCase.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getVms', () => {
+    it('should return paginated VMs', async () => {
+      const mock = { items: [createMockVm()] } as any;
+      getVmListUseCase.execute.mockResolvedValue(mock);
+      const result = await controller.getVms('1', '5');
+      expect(result).toBe(mock);
+      expect(getVmListUseCase.execute).toHaveBeenCalledWith(1, 5);
+    });
+
+    it('should use default pagination', async () => {
+      const mock = { items: [] } as any;
+      getVmListUseCase.execute.mockResolvedValue(mock);
+      const result = await controller.getVms();
+      expect(result).toBe(mock);
+      expect(getVmListUseCase.execute).toHaveBeenCalledWith(1, 10);
     });
   });
 

--- a/src/modules/vms/application/controllers/vm.controller.ts
+++ b/src/modules/vms/application/controllers/vm.controller.ts
@@ -7,11 +7,13 @@ import {
   Patch,
   Post,
   ParseUUIDPipe,
+  Query,
   UseGuards,
   UseFilters,
 } from '@nestjs/common';
 import { VmCreationDto } from '../dto/vm.creation.dto';
 import { VmResponseDto } from '../dto/vm.response.dto';
+import { VmListResponseDto } from '../dto/vm.list.response.dto';
 import { VmEndpointInterface } from '../interfaces/vm.endpoint.interface';
 import { VmUpdateDto } from '../dto/vm.update.dto';
 import {
@@ -20,11 +22,13 @@ import {
   ApiParam,
   ApiBody,
   ApiBearerAuth,
+  ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
 import {
   CreateVmUseCase,
   DeleteVmUseCase,
+  GetVmListUseCase,
   GetAllVmsUseCase,
   GetVmByIdUseCase,
   UpdateVmUseCase,
@@ -40,6 +44,7 @@ import { InvalidQueryExceptionFilter } from '@/core/filters/invalid-query.except
 export class VmController implements VmEndpointInterface {
   constructor(
     private readonly getAllVmsUseCase: GetAllVmsUseCase,
+    private readonly getVmListUseCase: GetVmListUseCase,
     private readonly getVmByIdUseCase: GetVmByIdUseCase,
     private readonly createVmUseCase: CreateVmUseCase,
     private readonly updateVmUseCase: UpdateVmUseCase,
@@ -47,11 +52,19 @@ export class VmController implements VmEndpointInterface {
   ) {}
 
   @Get()
-  @ApiOperation({
-    summary: 'Lister toutes les machines virtuelles',
-    description:
-      'Renvoie toutes les machines virtuelles enregistrées dans le système.',
-  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOperation({ summary: 'Lister les VMs paginées' })
+  @ApiResponse({ status: 200, type: VmListResponseDto })
+  async getVms(
+    @Query('page') page = '1',
+    @Query('limit') limit = '10',
+  ): Promise<VmListResponseDto> {
+    return this.getVmListUseCase.execute(Number(page), Number(limit));
+  }
+
+  @Get('all')
+  @ApiOperation({ summary: 'Lister toutes les machines virtuelles' })
   @ApiResponse({ status: 200, type: [VmResponseDto] })
   async getAllVms(): Promise<VmResponseDto[]> {
     return this.getAllVmsUseCase.execute();

--- a/src/modules/vms/application/dto/__tests__/vm.list.response.dto.spec.ts
+++ b/src/modules/vms/application/dto/__tests__/vm.list.response.dto.spec.ts
@@ -1,0 +1,21 @@
+import { createMockVm } from '@/modules/vms/__mocks__/vms.mock';
+import { VmResponseDto } from '../vm.response.dto';
+import { VmListResponseDto } from '../vm.list.response.dto';
+
+describe('VmListResponseDto', () => {
+  it('should set properties correctly', () => {
+    const items = [new VmResponseDto(createMockVm())];
+    const dto = new VmListResponseDto(items, 5, 1, 2);
+    expect(dto.items).toEqual(items);
+    expect(dto.totalItems).toBe(5);
+    expect(dto.currentPage).toBe(1);
+    expect(dto.totalPages).toBe(3);
+  });
+
+  it('should support empty list', () => {
+    const dto = new VmListResponseDto([], 0, 1, 10);
+    expect(dto.items).toEqual([]);
+    expect(dto.totalItems).toBe(0);
+    expect(dto.totalPages).toBe(0);
+  });
+});

--- a/src/modules/vms/application/dto/index.ts
+++ b/src/modules/vms/application/dto/index.ts
@@ -1,0 +1,6 @@
+import { VmCreationDto } from './vm.creation.dto';
+import { VmResponseDto } from './vm.response.dto';
+import { VmUpdateDto } from './vm.update.dto';
+import { VmListResponseDto } from './vm.list.response.dto';
+
+export { VmCreationDto, VmResponseDto, VmUpdateDto, VmListResponseDto };

--- a/src/modules/vms/application/dto/vm.list.response.dto.ts
+++ b/src/modules/vms/application/dto/vm.list.response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaginatedResponseDto } from '@/core/dto';
+import { VmResponseDto } from './vm.response.dto';
+
+export class VmListResponseDto extends PaginatedResponseDto<VmResponseDto> {
+  @ApiProperty({ type: () => VmResponseDto, isArray: true })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => VmResponseDto)
+  readonly items: VmResponseDto[];
+
+  constructor(
+    items: VmResponseDto[],
+    totalItems: number,
+    currentPage: number,
+    pageSize: number,
+  ) {
+    super(items, totalItems, currentPage, pageSize);
+  }
+}

--- a/src/modules/vms/application/use-cases/__tests__/get-vm-list.use-case.spec.ts
+++ b/src/modules/vms/application/use-cases/__tests__/get-vm-list.use-case.spec.ts
@@ -1,0 +1,34 @@
+import { GetVmListUseCase } from '../get-vm-list.use-case';
+import { VmRepositoryInterface } from '@/modules/vms/domain/interfaces/vm.repository.interface';
+import { createMockVm } from '@/modules/vms/__mocks__/vms.mock';
+
+describe('GetVmListUseCase', () => {
+  let repo: jest.Mocked<VmRepositoryInterface>;
+  let useCase: GetVmListUseCase;
+
+  beforeEach(() => {
+    repo = { paginate: jest.fn() } as any;
+    useCase = new GetVmListUseCase(repo);
+  });
+
+  it('should return paginated VMs', async () => {
+    const vms = [createMockVm({ id: 'vm-1' })];
+    repo.paginate.mockResolvedValue([vms, 1]);
+
+    const result = await useCase.execute(2, 5);
+
+    expect(repo.paginate).toHaveBeenCalledWith(2, 5);
+    expect(result.items).toHaveLength(1);
+    expect(result.totalItems).toBe(1);
+    expect(result.currentPage).toBe(2);
+  });
+
+  it('should handle empty list', async () => {
+    repo.paginate.mockResolvedValue([[], 0]);
+
+    const result = await useCase.execute();
+
+    expect(result.items).toEqual([]);
+    expect(result.totalItems).toBe(0);
+  });
+});

--- a/src/modules/vms/application/use-cases/get-vm-list.use-case.ts
+++ b/src/modules/vms/application/use-cases/get-vm-list.use-case.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { VmRepositoryInterface } from '../../domain/interfaces/vm.repository.interface';
+import { VmResponseDto } from '../dto/vm.response.dto';
+import { VmListResponseDto } from '../dto/vm.list.response.dto';
+
+@Injectable()
+export class GetVmListUseCase {
+  constructor(
+    @Inject('VmRepositoryInterface')
+    private readonly repo: VmRepositoryInterface,
+  ) {}
+
+  async execute(page = 1, limit = 10): Promise<VmListResponseDto> {
+    const [vms, total] = await this.repo.paginate(page, limit);
+    const items = vms.map((v) => new VmResponseDto(v));
+    return new VmListResponseDto(items, total, page, limit);
+  }
+}

--- a/src/modules/vms/application/use-cases/index.ts
+++ b/src/modules/vms/application/use-cases/index.ts
@@ -3,8 +3,10 @@ import { GetVmByIdUseCase } from './get-vm-by-id.use-case';
 import { CreateVmUseCase } from './create-vm.use-case';
 import { UpdateVmUseCase } from './update-vm.use-case';
 import { DeleteVmUseCase } from './delete-vm.use-case';
+import { GetVmListUseCase } from './get-vm-list.use-case';
 
 export const VmUseCase = [
+  GetVmListUseCase,
   GetAllVmsUseCase,
   GetVmByIdUseCase,
   CreateVmUseCase,
@@ -18,4 +20,5 @@ export {
   CreateVmUseCase,
   UpdateVmUseCase,
   DeleteVmUseCase,
+  GetVmListUseCase,
 };

--- a/src/modules/vms/domain/interfaces/vm.repository.interface.ts
+++ b/src/modules/vms/domain/interfaces/vm.repository.interface.ts
@@ -5,4 +5,12 @@ export interface VmRepositoryInterface extends GenericRepositoryInterface<Vm> {
   findVmById(id: string): Promise<Vm>;
   save(vm: Vm): Promise<Vm>;
   deleteVm(id: string): Promise<void>;
+
+  /**
+   * Retrieve VMs with pagination.
+   *
+   * @param page - page number starting at 1
+   * @param limit - items per page
+   */
+  paginate(page: number, limit: number): Promise<[Vm[], number]>;
 }

--- a/src/modules/vms/infrastructure/repositories/vm.typeorm.repository.ts
+++ b/src/modules/vms/infrastructure/repositories/vm.typeorm.repository.ts
@@ -57,6 +57,15 @@ export class VmTypeormRepository
     }
   }
 
+  async paginate(page: number, limit: number): Promise<[Vm[], number]> {
+    return this.findAndCount({
+      relations: ['permissions'],
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { name: 'ASC' },
+    });
+  }
+
   async findVmById(id: string): Promise<Vm> {
     const vm = await this.findOne({
       where: { id },


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * Added paginated endpoints for listing rooms and virtual machines, accessible via new GET endpoints with support for `page`, `limit`, and optional `includeCounts` query parameters.
  * Updated API documentation to reflect new paginated responses.
  * Moved previous endpoints for retrieving all rooms and all virtual machines to `/room/all` and `/vm/all`.
  * Introduced paginated response formats for rooms and virtual machines, including optional counts of related entities for rooms.

* **Bug Fixes**
  * None.

* **Tests**
  * Added comprehensive unit tests for new paginated response DTOs and use cases for both rooms and virtual machines.
  * Extended controller test suites to cover paginated endpoints.

* **Chores**
  * Added and updated mock implementations to support pagination in testing environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated endpoints for listing rooms, virtual machines (VMs), and user-accessible servers, with support for page and limit query parameters.
  * Responses for room, VM, and server lists now include pagination metadata (total items, current page, total pages).
  * Room list responses can optionally include server and UPS device counts per room.

* **Bug Fixes**
  * None.

* **Tests**
  * Introduced comprehensive tests for paginated list DTOs and use cases for rooms, VMs, and servers.
  * Updated controller and use case tests to validate pagination behavior and edge cases.

* **Documentation**
  * Enhanced API documentation to reflect new paginated endpoints and query parameters.

* **Chores**
  * Added and updated mock utilities for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->