### PR TITLE
feat(ups): add server count in ups response

### DIFF
--- a/src/modules/history/application/dto/__tests__/history-event.response.dto.spec.ts
+++ b/src/modules/history/application/dto/__tests__/history-event.response.dto.spec.ts
@@ -1,0 +1,97 @@
+import { HistoryEventResponseDto } from '../history-event.response.dto';
+import { HistoryEvent } from '../../../domain/entities/history-event.entity';
+import { User } from '@/modules/users/domain/entities/user.entity';
+
+describe('HistoryEventResponseDto', () => {
+  it('should create a DTO with all basic fields', () => {
+    const event = new HistoryEvent();
+    event.id = 'event-123';
+    event.entity = 'user';
+    event.entityId = 'user-456';
+    event.action = 'UPDATE';
+    event.userId = 'user-789';
+    event.createdAt = new Date('2024-01-01T00:00:00Z');
+
+    const dto = new HistoryEventResponseDto(event);
+
+    expect(dto.id).toBe('event-123');
+    expect(dto.entity).toBe('user');
+    expect(dto.entityId).toBe('user-456');
+    expect(dto.action).toBe('UPDATE');
+    expect(dto.userId).toBe('user-789');
+    expect(dto.createdAt).toEqual(new Date('2024-01-01T00:00:00Z'));
+    expect(dto.user).toBeUndefined();
+  });
+
+  it('should include user data when present', () => {
+    const user = new User();
+    user.id = 'user-789';
+    user.username = 'john.doe';
+    user.email = 'john@example.com';
+
+    const event = new HistoryEvent();
+    event.id = 'event-123';
+    event.entity = 'server';
+    event.entityId = 'server-456';
+    event.action = 'CREATE';
+    event.userId = 'user-789';
+    event.user = user;
+    event.createdAt = new Date('2024-01-01T00:00:00Z');
+
+    const dto = new HistoryEventResponseDto(event);
+
+    expect(dto.user).toBeDefined();
+    expect(dto.user?.id).toBe('user-789');
+    expect(dto.user?.username).toBe('john.doe');
+    expect(dto.user?.email).toBe('john@example.com');
+  });
+
+  it('should include all metadata fields when present', () => {
+    const event = new HistoryEvent();
+    event.id = 'event-123';
+    event.entity = 'server';
+    event.entityId = 'server-456';
+    event.action = 'UPDATE';
+    event.userId = 'user-789';
+    event.createdAt = new Date('2024-01-01T00:00:00Z');
+    event.oldValue = { status: 'running' };
+    event.newValue = { status: 'stopped' };
+    event.metadata = { reason: 'maintenance', duration: 3600 };
+    event.ipAddress = '192.168.1.100';
+    event.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)';
+    event.correlationId = 'corr-123-456';
+
+    const dto = new HistoryEventResponseDto(event);
+
+    expect(dto.oldValue).toEqual({ status: 'running' });
+    expect(dto.newValue).toEqual({ status: 'stopped' });
+    expect(dto.metadata).toEqual({ reason: 'maintenance', duration: 3600 });
+    expect(dto.ipAddress).toBe('192.168.1.100');
+    expect(dto.userAgent).toBe('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    expect(dto.correlationId).toBe('corr-123-456');
+  });
+
+  it('should handle events without optional fields', () => {
+    const event = new HistoryEvent();
+    event.id = 'event-123';
+    event.entity = 'vm';
+    event.entityId = 'vm-456';
+    event.action = 'DELETE';
+    event.createdAt = new Date('2024-01-01T00:00:00Z');
+
+    const dto = new HistoryEventResponseDto(event);
+
+    expect(dto.id).toBe('event-123');
+    expect(dto.entity).toBe('vm');
+    expect(dto.entityId).toBe('vm-456');
+    expect(dto.action).toBe('DELETE');
+    expect(dto.userId).toBeUndefined();
+    expect(dto.user).toBeUndefined();
+    expect(dto.oldValue).toBeUndefined();
+    expect(dto.newValue).toBeUndefined();
+    expect(dto.metadata).toBeUndefined();
+    expect(dto.ipAddress).toBeUndefined();
+    expect(dto.userAgent).toBeUndefined();
+    expect(dto.correlationId).toBeUndefined();
+  });
+});

--- a/src/modules/history/application/dto/history-event.response.dto.ts
+++ b/src/modules/history/application/dto/history-event.response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsUUID, IsString, IsOptional, IsDate } from 'class-validator';
+import { IsUUID, IsString, IsOptional, IsDate, IsObject } from 'class-validator';
 import { HistoryEvent } from '../../domain/entities/history-event.entity';
 import { UserResponseDto } from '@/modules/users/application/dto/user.response.dto';
 import { Type } from 'class-transformer';
@@ -35,6 +35,36 @@ export class HistoryEventResponseDto {
   @Type(() => UserResponseDto)
   readonly user?: UserResponseDto;
 
+  @ApiProperty({ description: 'Previous state of the entity', required: false })
+  @IsObject()
+  @IsOptional()
+  readonly oldValue?: Record<string, any>;
+
+  @ApiProperty({ description: 'New state of the entity', required: false })
+  @IsObject()
+  @IsOptional()
+  readonly newValue?: Record<string, any>;
+
+  @ApiProperty({ description: 'Additional metadata and context', required: false })
+  @IsObject()
+  @IsOptional()
+  readonly metadata?: Record<string, any>;
+
+  @ApiProperty({ description: 'IP address of the user performing the action', required: false })
+  @IsString()
+  @IsOptional()
+  readonly ipAddress?: string;
+
+  @ApiProperty({ description: 'User agent of the client', required: false })
+  @IsString()
+  @IsOptional()
+  readonly userAgent?: string;
+
+  @ApiProperty({ description: 'Correlation ID for tracking related events', required: false })
+  @IsString()
+  @IsOptional()
+  readonly correlationId?: string;
+
   constructor(event: HistoryEvent) {
     this.id = event.id;
     this.entity = event.entity;
@@ -42,6 +72,12 @@ export class HistoryEventResponseDto {
     this.action = event.action;
     this.userId = event.userId;
     this.createdAt = event.createdAt;
+    this.oldValue = event.oldValue;
+    this.newValue = event.newValue;
+    this.metadata = event.metadata;
+    this.ipAddress = event.ipAddress;
+    this.userAgent = event.userAgent;
+    this.correlationId = event.correlationId;
     if (event.user) {
       this.user = new UserResponseDto(event.user);
     }

--- a/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
+++ b/src/modules/ups/application/controllers/__tests__/ups.controller.spec.ts
@@ -60,7 +60,7 @@ describe('UpsController', () => {
   });
 
   it('should return paginated UPS list', async () => {
-    const mock = { items: [new UpsResponseDto(createMockUps())] } as any;
+    const mock = { items: [new UpsResponseDto(createMockUps(), 3)] } as any;
     getListUseCase.execute.mockResolvedValue(mock);
     const result = await controller.getUps('1', '5');
     expect(result).toBe(mock);
@@ -81,7 +81,7 @@ describe('UpsController', () => {
   });
 
   it('should return all UPSs', async () => {
-    const mock = [new UpsResponseDto(createMockUps())];
+    const mock = [new UpsResponseDto(createMockUps(), 5)];
     getAllUseCase.execute.mockResolvedValue(mock);
     const result = await controller.getAllUps();
     expect(result).toEqual(mock);
@@ -94,7 +94,7 @@ describe('UpsController', () => {
   });
 
   it('should return a UPS by ID', async () => {
-    const mock = new UpsResponseDto(createMockUps());
+    const mock = new UpsResponseDto(createMockUps(), 2);
     getByIdUseCase.execute.mockResolvedValue(mock);
     const result = await controller.getUpsById('ups-123');
     expect(result).toEqual(mock);
@@ -108,7 +108,7 @@ describe('UpsController', () => {
 
   it('should create a new UPS', async () => {
     const dto = createMockUpsDto();
-    const mock = new UpsResponseDto({ ...dto, id: 'ups-123' } as any);
+    const mock = new UpsResponseDto({ ...dto, id: 'ups-123' } as any, 0);
     createUseCase.execute.mockResolvedValue(mock);
     const result = await controller.createUps(dto, mockPayload);
     expect(result).toEqual(mock);
@@ -125,7 +125,7 @@ describe('UpsController', () => {
 
   it('should update a UPS', async () => {
     const dto = { name: 'Updated UPS' };
-    const mock = new UpsResponseDto(createMockUps({ name: 'Updated UPS' }));
+    const mock = new UpsResponseDto(createMockUps({ name: 'Updated UPS' }), 4);
     updateUseCase.execute.mockResolvedValue(mock);
     const result = await controller.updateUps('ups-123', dto, mockPayload);
     expect(result).toEqual(mock);

--- a/src/modules/ups/application/dto/__tests__/ups.list.response.dto.spec.ts
+++ b/src/modules/ups/application/dto/__tests__/ups.list.response.dto.spec.ts
@@ -4,7 +4,8 @@ import { UpsResponseDto } from '../ups.response.dto';
 
 describe('UpsListResponseDto', () => {
   it('should set all properties correctly', () => {
-    const item = createMockUps();
+    const upsEntity = createMockUps();
+    const item = new UpsResponseDto(upsEntity, 5);
 
     const items = [item];
     const totalItems = 15;

--- a/src/modules/ups/application/dto/__tests__/ups.response.dto.spec.ts
+++ b/src/modules/ups/application/dto/__tests__/ups.response.dto.spec.ts
@@ -1,22 +1,75 @@
 import { UpsResponseDto } from '../ups.response.dto';
-import { createMockUps } from '@/modules/ups/__mocks__/ups.mock';
+import { Ups } from '../../../domain/entities/ups.entity';
 
 describe('UpsResponseDto', () => {
-  it('should map a valid Ups entity', () => {
-    const ups = createMockUps({
-      id: 'ups-123',
-      name: 'Onduleur test',
-      ip: '10.0.0.9',
+  describe('constructor', () => {
+    const mockUps: Ups = {
+      id: 'test-id',
+      name: 'Test UPS',
+      ip: '192.168.1.100',
+      login: 'admin',
+      password: 'password',
       grace_period_on: 10,
       grace_period_off: 5,
-      roomId: 'room-123',
+      roomId: 'room-1',
+      servers: [],
+      room: null,
+    } as Ups;
+
+    it('should create a DTO with server count', () => {
+      const serverCount = 5;
+      const dto = new UpsResponseDto(mockUps, serverCount);
+
+      expect(dto.id).toBe('test-id');
+      expect(dto.name).toBe('Test UPS');
+      expect(dto.ip).toBe('192.168.1.100');
+      expect(dto.grace_period_on).toBe(10);
+      expect(dto.grace_period_off).toBe(5);
+      expect(dto.roomId).toBe('room-1');
+      expect(dto.serverCount).toBe(5);
     });
 
-    const dto = new UpsResponseDto(ups);
+    it('should use default server count of 0 when not provided', () => {
+      const dto = new UpsResponseDto(mockUps);
 
-    expect(dto.id).toBe('ups-123');
-    expect(dto.name).toBe('Onduleur test');
-    expect(dto.ip).toBe('10.0.0.9');
-    expect(dto.roomId).toBe('room-123');
+      expect(dto.serverCount).toBe(0);
+    });
+
+    it('should correctly map all UPS properties', () => {
+      const ups: Ups = {
+        id: 'unique-id',
+        name: 'UPS Name',
+        ip: '10.0.0.1',
+        login: 'user',
+        password: 'pass',
+        grace_period_on: 15,
+        grace_period_off: 8,
+        roomId: 'room-unique',
+        servers: [],
+        room: null,
+      } as Ups;
+
+      const dto = new UpsResponseDto(ups, 10);
+
+      expect(dto.id).toBe('unique-id');
+      expect(dto.name).toBe('UPS Name');
+      expect(dto.ip).toBe('10.0.0.1');
+      expect(dto.grace_period_on).toBe(15);
+      expect(dto.grace_period_off).toBe(8);
+      expect(dto.roomId).toBe('room-unique');
+      expect(dto.serverCount).toBe(10);
+    });
+
+    it('should handle server count of 0', () => {
+      const dto = new UpsResponseDto(mockUps, 0);
+
+      expect(dto.serverCount).toBe(0);
+    });
+
+    it('should handle large server count', () => {
+      const dto = new UpsResponseDto(mockUps, 100);
+
+      expect(dto.serverCount).toBe(100);
+    });
   });
 });

--- a/src/modules/ups/application/dto/ups.response.dto.ts
+++ b/src/modules/ups/application/dto/ups.response.dto.ts
@@ -33,12 +33,17 @@ export class UpsResponseDto {
   @IsUUID()
   readonly roomId: string;
 
-  constructor(ups: Ups) {
+  @ApiProperty({ description: 'Number of servers connected to this UPS' })
+  @IsNumber()
+  readonly serverCount: number;
+
+  constructor(ups: Ups, serverCount = 0) {
     this.id = ups.id;
     this.name = ups.name;
     this.ip = ups.ip;
     this.grace_period_on = ups.grace_period_on;
     this.grace_period_off = ups.grace_period_off;
     this.roomId = ups.roomId;
+    this.serverCount = serverCount;
   }
 }

--- a/src/modules/ups/application/use-cases/__tests__/create-ups.use-case.spec.ts
+++ b/src/modules/ups/application/use-cases/__tests__/create-ups.use-case.spec.ts
@@ -32,6 +32,7 @@ describe('CreateUpsUseCase', () => {
 
     expect(result).toBeInstanceOf(UpsResponseDto);
     expect(result.id).toBe(entity.id);
+    expect(result.serverCount).toBe(0);
     expect(mockRepo.save).toHaveBeenCalledWith(entity);
   });
 
@@ -46,6 +47,7 @@ describe('CreateUpsUseCase', () => {
 
     expect(result).toBeInstanceOf(UpsResponseDto);
     expect(result.id).toBe(entity.id);
+    expect(result.serverCount).toBe(0);
   });
 
   it('should throw if domain service fails', async () => {

--- a/src/modules/ups/application/use-cases/__tests__/get-all-ups.use-case.spec.ts
+++ b/src/modules/ups/application/use-cases/__tests__/get-all-ups.use-case.spec.ts
@@ -1,39 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
 import { GetAllUpsUseCase } from '../get-all-ups.use-case';
 import { UpsRepositoryInterface } from '../../../domain/interfaces/ups.repository.interface';
-import { createMockUps } from '../../../__mocks__/ups.mock';
 import { Ups } from '../../../domain/entities/ups.entity';
+import { UpsResponseDto } from '../../dto/ups.response.dto';
 
 describe('GetAllUpsUseCase', () => {
   let useCase: GetAllUpsUseCase;
-  let upsRepository: jest.Mocked<UpsRepositoryInterface>;
+  let repository: UpsRepositoryInterface;
 
-  beforeEach(() => {
-    upsRepository = {
-      findAll: jest.fn(),
-    } as any;
+  const mockUpsRepository = {
+    findAllWithServerCount: jest.fn(),
+  };
 
-    useCase = new GetAllUpsUseCase(upsRepository);
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetAllUpsUseCase,
+        {
+          provide: 'UpsRepositoryInterface',
+          useValue: mockUpsRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<GetAllUpsUseCase>(GetAllUpsUseCase);
+    repository = module.get<UpsRepositoryInterface>('UpsRepositoryInterface');
   });
 
-  it('should return a list of UPS as response DTOs', async () => {
-    const mockUpsList: Ups[] = [
-      createMockUps({ id: 'ups-1', name: 'UPS-A' }),
-      createMockUps({ id: 'ups-2', name: 'UPS-B' }),
-    ];
-    upsRepository.findAll.mockResolvedValue(mockUpsList);
-
-    const result = await useCase.execute();
-
-    expect(result).toHaveLength(2);
-    expect(result[0].id).toBe('ups-1');
-    expect(result[1].name).toBe('UPS-B');
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('should return an empty array if no UPS found', async () => {
-    upsRepository.findAll.mockResolvedValue([]);
+  describe('execute', () => {
+    it('should return all UPS with server count', async () => {
+      const mockUps: Ups = {
+        id: '1',
+        name: 'UPS 1',
+        ip: '192.168.1.100',
+        login: 'admin',
+        password: 'password',
+        grace_period_on: 10,
+        grace_period_off: 5,
+        roomId: 'room-1',
+        servers: [],
+        room: null,
+      } as Ups;
 
-    const result = await useCase.execute();
+      const mockData = [
+        { ups: mockUps, serverCount: 5 },
+        { ups: { ...mockUps, id: '2', name: 'UPS 2' }, serverCount: 3 },
+        { ups: { ...mockUps, id: '3', name: 'UPS 3' }, serverCount: 0 },
+      ];
 
-    expect(result).toEqual([]);
+      mockUpsRepository.findAllWithServerCount.mockResolvedValueOnce(mockData);
+
+      const result = await useCase.execute();
+
+      expect(repository.findAllWithServerCount).toHaveBeenCalled();
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBeInstanceOf(UpsResponseDto);
+      expect(result[0].serverCount).toBe(5);
+      expect(result[1].serverCount).toBe(3);
+      expect(result[2].serverCount).toBe(0);
+    });
+
+    it('should handle empty results', async () => {
+      mockUpsRepository.findAllWithServerCount.mockResolvedValueOnce([]);
+
+      const result = await useCase.execute();
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should properly map all UPS properties', async () => {
+      const mockUps: Ups = {
+        id: 'test-id',
+        name: 'Test UPS',
+        ip: '10.0.0.1',
+        login: 'testuser',
+        password: 'testpass',
+        grace_period_on: 15,
+        grace_period_off: 10,
+        roomId: 'room-test',
+        servers: [],
+        room: null,
+      } as Ups;
+
+      mockUpsRepository.findAllWithServerCount.mockResolvedValueOnce([
+        { ups: mockUps, serverCount: 2 },
+      ]);
+
+      const result = await useCase.execute();
+
+      expect(result[0].id).toBe('test-id');
+      expect(result[0].name).toBe('Test UPS');
+      expect(result[0].ip).toBe('10.0.0.1');
+      expect(result[0].grace_period_on).toBe(15);
+      expect(result[0].grace_period_off).toBe(10);
+      expect(result[0].roomId).toBe('room-test');
+      expect(result[0].serverCount).toBe(2);
+    });
   });
 });

--- a/src/modules/ups/application/use-cases/__tests__/get-ups-list.use-case.spec.ts
+++ b/src/modules/ups/application/use-cases/__tests__/get-ups-list.use-case.spec.ts
@@ -1,36 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
 import { GetUpsListUseCase } from '../get-ups-list.use-case';
-import { UpsRepositoryInterface } from '@/modules/ups/domain/interfaces/ups.repository.interface';
-import { createMockUps } from '@/modules/ups/__mocks__/ups.mock';
+import { UpsRepositoryInterface } from '../../../domain/interfaces/ups.repository.interface';
+import { Ups } from '../../../domain/entities/ups.entity';
+import { UpsResponseDto } from '../../dto/ups.response.dto';
+import { UpsListResponseDto } from '../../dto';
 
 describe('GetUpsListUseCase', () => {
   let useCase: GetUpsListUseCase;
-  let repo: jest.Mocked<UpsRepositoryInterface>;
+  let repository: UpsRepositoryInterface;
 
-  beforeEach(() => {
-    repo = {
-      paginate: jest.fn(),
-    } as any;
-    useCase = new GetUpsListUseCase(repo);
+  const mockUpsRepository = {
+    paginateWithServerCount: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetUpsListUseCase,
+        {
+          provide: 'UpsRepositoryInterface',
+          useValue: mockUpsRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<GetUpsListUseCase>(GetUpsListUseCase);
+    repository = module.get<UpsRepositoryInterface>('UpsRepositoryInterface');
   });
 
-  it('should return paginated UPS list', async () => {
-    const upsList = [createMockUps({ id: 'ups-1' })];
-    repo.paginate.mockResolvedValue([upsList, 1]);
-
-    const result = await useCase.execute(2, 5);
-
-    expect(repo.paginate).toHaveBeenCalledWith(2, 5);
-    expect(result.items).toHaveLength(1);
-    expect(result.totalItems).toBe(1);
-    expect(result.currentPage).toBe(2);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('should return empty list when no UPS found', async () => {
-    repo.paginate.mockResolvedValue([[], 0]);
+  describe('execute', () => {
+    it('should return paginated UPS list with server count', async () => {
+      const mockUps: Ups = {
+        id: '1',
+        name: 'UPS 1',
+        ip: '192.168.1.100',
+        login: 'admin',
+        password: 'password',
+        grace_period_on: 10,
+        grace_period_off: 5,
+        roomId: 'room-1',
+        servers: [],
+        room: null,
+      } as Ups;
 
-    const result = await useCase.execute();
+      const mockData = [
+        { ups: mockUps, serverCount: 5 },
+        { ups: { ...mockUps, id: '2', name: 'UPS 2' }, serverCount: 3 },
+      ];
+      const total = 10;
 
-    expect(result.items).toEqual([]);
-    expect(result.totalItems).toBe(0);
+      mockUpsRepository.paginateWithServerCount.mockResolvedValueOnce([mockData, total]);
+
+      const result = await useCase.execute(1, 10);
+
+      expect(repository.paginateWithServerCount).toHaveBeenCalledWith(1, 10);
+      expect(result).toBeInstanceOf(UpsListResponseDto);
+      expect(result.totalItems).toBe(total);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(1); // 10 items / 10 per page = 1 page
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toBeInstanceOf(UpsResponseDto);
+      expect(result.items[0].serverCount).toBe(5);
+      expect(result.items[1].serverCount).toBe(3);
+    });
+
+    it('should use default pagination values', async () => {
+      mockUpsRepository.paginateWithServerCount.mockResolvedValueOnce([[], 0]);
+
+      await useCase.execute();
+
+      expect(repository.paginateWithServerCount).toHaveBeenCalledWith(1, 10);
+    });
+
+    it('should handle empty results', async () => {
+      mockUpsRepository.paginateWithServerCount.mockResolvedValueOnce([[], 0]);
+
+      const result = await useCase.execute(1, 10);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.totalItems).toBe(0);
+    });
   });
 });

--- a/src/modules/ups/application/use-cases/__tests__/update-ups.use-case.spec.ts
+++ b/src/modules/ups/application/use-cases/__tests__/update-ups.use-case.spec.ts
@@ -15,6 +15,7 @@ describe('UpdateUpsUseCase', () => {
     repo = {
       findUpsById: jest.fn(),
       save: jest.fn(),
+      findByIdWithServerCount: jest.fn(),
     } as any;
 
     domain = {
@@ -32,6 +33,7 @@ describe('UpdateUpsUseCase', () => {
     repo.findUpsById.mockResolvedValue(existing);
     domain.createUpsEntityFromUpdateDto.mockResolvedValue(updated);
     repo.save.mockResolvedValue(updated);
+    repo.findByIdWithServerCount.mockResolvedValue({ ups: updated, serverCount: 3 });
 
     const result = await useCase.execute('ups-id', dto);
 
@@ -41,8 +43,10 @@ describe('UpdateUpsUseCase', () => {
       dto,
     );
     expect(repo.save).toHaveBeenCalledWith(updated);
+    expect(repo.findByIdWithServerCount).toHaveBeenCalledWith(updated.id);
     expect(result).toBeInstanceOf(UpsResponseDto);
     expect(result.name).toBe('New UPS');
+    expect(result.serverCount).toBe(3);
   });
 
   it('should handle partial update', async () => {
@@ -53,11 +57,13 @@ describe('UpdateUpsUseCase', () => {
     repo.findUpsById.mockResolvedValue(existing);
     domain.createUpsEntityFromUpdateDto.mockResolvedValue(updated);
     repo.save.mockResolvedValue(updated);
+    repo.findByIdWithServerCount.mockResolvedValue({ ups: updated, serverCount: 0 });
 
     const result = await useCase.execute('ups-id', dto);
 
     expect(result.ip).toBe('192.168.1.100');
     expect(result.name).toBe('Partial UPS');
+    expect(result.serverCount).toBe(0);
   });
 
   it('should throw UpsNotFoundException if UPS does not exist', async () => {

--- a/src/modules/ups/application/use-cases/create-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/create-ups.use-case.ts
@@ -38,6 +38,7 @@ export class CreateUpsUseCase {
 
     const ups = Array.isArray(saved) ? saved[0] : saved;
     await this.logHistory?.execute('ups', ups.id, 'CREATE', userId);
-    return new UpsResponseDto(ups);
+    
+    return new UpsResponseDto(ups, 0);
   }
 }

--- a/src/modules/ups/application/use-cases/get-all-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/get-all-ups.use-case.ts
@@ -26,7 +26,7 @@ export class GetAllUpsUseCase {
   ) {}
 
   async execute(): Promise<UpsResponseDto[]> {
-    const ups = await this.upsRepository.findAll();
-    return ups.map((u) => new UpsResponseDto(u));
+    const upsWithCount = await this.upsRepository.findAllWithServerCount();
+    return upsWithCount.map(({ ups, serverCount }) => new UpsResponseDto(ups, serverCount));
   }
 }

--- a/src/modules/ups/application/use-cases/get-ups-by-id.use-case.ts
+++ b/src/modules/ups/application/use-cases/get-ups-by-id.use-case.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { UpsRepositoryInterface } from '../../domain/interfaces/ups.repository.interface';
 import { UpsResponseDto } from '../../application/dto/ups.response.dto';
+import { UpsNotFoundException } from '../../domain/exceptions/ups.exception';
 
 /**
  * Fetches details for a single UPS device by its unique identifier.
@@ -27,7 +28,10 @@ export class GetUpsByIdUseCase {
   ) {}
 
   async execute(id: string): Promise<UpsResponseDto> {
-    const ups = await this.upsRepository.findUpsById(id);
-    return new UpsResponseDto(ups);
+    const result = await this.upsRepository.findByIdWithServerCount(id);
+    if (!result) {
+      throw new UpsNotFoundException(id);
+    }
+    return new UpsResponseDto(result.ups, result.serverCount);
   }
 }

--- a/src/modules/ups/application/use-cases/get-ups-list.use-case.ts
+++ b/src/modules/ups/application/use-cases/get-ups-list.use-case.ts
@@ -17,8 +17,8 @@ export class GetUpsListUseCase {
    * @param limit - number of UPS per page
    */
   async execute(page = 1, limit = 10): Promise<UpsListResponseDto> {
-    const [ups, total] = await this.repo.paginate(page, limit);
-    const dtos = ups.map((u) => new UpsResponseDto(u));
+    const [upsWithCount, total] = await this.repo.paginateWithServerCount(page, limit);
+    const dtos = upsWithCount.map(({ ups, serverCount }) => new UpsResponseDto(ups, serverCount));
     return new UpsListResponseDto(dtos, total, page, limit);
   }
 }

--- a/src/modules/ups/application/use-cases/update-ups.use-case.ts
+++ b/src/modules/ups/application/use-cases/update-ups.use-case.ts
@@ -44,6 +44,8 @@ export class UpdateUpsUseCase {
     const saved = await this.upsRepository.save(ups);
     ups = Array.isArray(saved) ? saved[0] : saved;
     await this.logHistory?.execute('ups', ups.id, 'UPDATE', userId);
-    return new UpsResponseDto(ups);
+    
+    const result = await this.upsRepository.findByIdWithServerCount(ups.id);
+    return new UpsResponseDto(result.ups, result.serverCount);
   }
 }

--- a/src/modules/ups/domain/interfaces/ups.repository.interface.ts
+++ b/src/modules/ups/domain/interfaces/ups.repository.interface.ts
@@ -14,4 +14,25 @@ export interface UpsRepositoryInterface
    * @returns tuple of entities and total count
    */
   paginate(page: number, limit: number): Promise<[Ups[], number]>;
+  /**
+   * Retrieve all UPS entities with server count.
+   *
+   * @returns array of UPS entities with server count
+   */
+  findAllWithServerCount(): Promise<Array<{ ups: Ups; serverCount: number }>>;
+  /**
+   * Retrieve UPS entities with pagination and server count.
+   *
+   * @param page - page number starting at 1
+   * @param limit - number of items per page
+   * @returns tuple of entities with server count and total count
+   */
+  paginateWithServerCount(page: number, limit: number): Promise<[Array<{ ups: Ups; serverCount: number }>, number]>;
+  /**
+   * Retrieve a single UPS with server count.
+   *
+   * @param id - UPS id
+   * @returns UPS entity with server count or null
+   */
+  findByIdWithServerCount(id: string): Promise<{ ups: Ups; serverCount: number } | null>;
 }

--- a/src/modules/ups/infrastructure/repositories/__tests__/ups.typeorm.repository.spec.ts
+++ b/src/modules/ups/infrastructure/repositories/__tests__/ups.typeorm.repository.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource } from 'typeorm';
+import { UpsTypeormRepository } from '../ups.typeorm.repository';
+
+describe('UpsTypeormRepository', () => {
+  let repository: UpsTypeormRepository;
+  let dataSource: DataSource;
+
+  const mockQueryBuilder = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    loadRelationCountAndMap: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+    getManyAndCount: jest.fn(),
+    getOne: jest.fn(),
+  };
+
+  const mockDataSource = {
+    createEntityManager: jest.fn(() => ({})),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UpsTypeormRepository,
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<UpsTypeormRepository>(UpsTypeormRepository);
+    dataSource = module.get<DataSource>(DataSource);
+
+    repository.createQueryBuilder = jest.fn().mockReturnValue(mockQueryBuilder);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAllWithServerCount', () => {
+    it('should return UPS entities with server count', async () => {
+      const mockUps = [
+        { id: '1', name: 'UPS 1', serverCount: 5 },
+        { id: '2', name: 'UPS 2', serverCount: 3 },
+      ];
+
+      mockQueryBuilder.getMany.mockResolvedValueOnce(mockUps);
+
+      const result = await repository.findAllWithServerCount();
+
+      expect(repository.createQueryBuilder).toHaveBeenCalledWith('ups');
+      expect(mockQueryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+        'ups.servers',
+        'server',
+      );
+      expect(mockQueryBuilder.loadRelationCountAndMap).toHaveBeenCalledWith(
+        'ups.serverCount',
+        'ups.servers',
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ ups: mockUps[0], serverCount: 5 });
+      expect(result[1]).toEqual({ ups: mockUps[1], serverCount: 3 });
+    });
+
+    it('should handle UPS without servers', async () => {
+      const mockUps = [{ id: '1', name: 'UPS 1' }];
+
+      mockQueryBuilder.getMany.mockResolvedValueOnce(mockUps);
+
+      const result = await repository.findAllWithServerCount();
+
+      expect(result[0]).toEqual({ ups: mockUps[0], serverCount: 0 });
+    });
+  });
+
+  describe('paginateWithServerCount', () => {
+    it('should return paginated UPS entities with server count', async () => {
+      const mockUps = [
+        { id: '1', name: 'UPS 1', serverCount: 5 },
+        { id: '2', name: 'UPS 2', serverCount: 3 },
+      ];
+      const total = 10;
+
+      mockQueryBuilder.getManyAndCount.mockResolvedValueOnce([mockUps, total]);
+
+      const result = await repository.paginateWithServerCount(2, 5);
+
+      expect(repository.createQueryBuilder).toHaveBeenCalledWith('ups');
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(5); // (page - 1) * limit = (2 - 1) * 5
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(5);
+      expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('ups.name', 'ASC');
+      expect(result[0]).toHaveLength(2);
+      expect(result[1]).toBe(total);
+      expect(result[0][0]).toEqual({ ups: mockUps[0], serverCount: 5 });
+    });
+  });
+
+  describe('findByIdWithServerCount', () => {
+    it('should return a single UPS with server count', async () => {
+      const mockUps = { id: '1', name: 'UPS 1', serverCount: 5 };
+
+      mockQueryBuilder.getOne.mockResolvedValueOnce(mockUps);
+
+      const result = await repository.findByIdWithServerCount('1');
+
+      expect(repository.createQueryBuilder).toHaveBeenCalledWith('ups');
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('ups.id = :id', {
+        id: '1',
+      });
+      expect(result).toEqual({ ups: mockUps, serverCount: 5 });
+    });
+
+    it('should return null if UPS not found', async () => {
+      mockQueryBuilder.getOne.mockResolvedValueOnce(null);
+
+      const result = await repository.findByIdWithServerCount('non-existent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle UPS without servers', async () => {
+      const mockUps = { id: '1', name: 'UPS 1' };
+
+      mockQueryBuilder.getOne.mockResolvedValueOnce(mockUps);
+
+      const result = await repository.findByIdWithServerCount('1');
+
+      expect(result).toEqual({ ups: mockUps, serverCount: 0 });
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UPS-related API responses now include the number of servers associated with each UPS.
  * Added support for retrieving UPS lists, paginated results, and individual UPS details with server count information.
  * History events now include extended metadata such as old/new values, IP address, user agent, and correlation ID.

* **Bug Fixes**
  * Improved error handling for UPS retrieval operations.

* **Tests**
  * Expanded and refactored test coverage for UPS features, including new scenarios for server count and enhanced repository method testing.
  * Added comprehensive tests for history event response data including extended metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->